### PR TITLE
Allow MaxItemCount with Insert Method and improve nullable types

### DIFF
--- a/ObservableCollection/MintPlayer.ObservableCollection.Extensions/Enums/ECollectionSide.cs
+++ b/ObservableCollection/MintPlayer.ObservableCollection.Extensions/Enums/ECollectionSide.cs
@@ -1,0 +1,13 @@
+﻿namespace MintPlayer.ObservableCollection.Extensions.Enums;
+
+/// <summary>
+/// Indicates the head or tail of the collection
+/// </summary>
+public enum ECollectionSide
+{
+    /// <summary>Head/front of the collection</summary>
+    Head,
+
+    /// <summary>Tail/end of the collection</summary>
+    Tail,
+}

--- a/ObservableCollection/MintPlayer.ObservableCollection.Extensions/MintPlayer.ObservableCollection.Extensions.csproj
+++ b/ObservableCollection/MintPlayer.ObservableCollection.Extensions/MintPlayer.ObservableCollection.Extensions.csproj
@@ -12,7 +12,7 @@
 
 		<IsPackable>true</IsPackable>
 		<PackageId>MintPlayer.ObservableCollection.Extensions</PackageId>
-		<Version>9.2.0</Version>
+		<Version>9.3.0</Version>
 		<Description>Extension methods for MintPlayer.ObservableCollection</Description>
 		<Company>MintPlayer</Company>
 		<Authors>Pieterjan De Clippel</Authors>

--- a/ObservableCollection/MintPlayer.ObservableCollection.Extensions/ObservableCollectionExtensions.cs
+++ b/ObservableCollection/MintPlayer.ObservableCollection.Extensions/ObservableCollectionExtensions.cs
@@ -89,9 +89,6 @@ public static class ObservableCollectionExtensions
     /// <summary>
     /// Insert an item at the specified index, and ensure the collection have at most <paramref name="maxItemCount"/> items.
     /// </summary>
-    /// <remarks>
-    /// If the <paramref name="index"/> is greater than or equal to the half of the collection count, exceeding items will be removed from the head of the collection, otherwise at the tail.
-    /// </remarks>
     /// <typeparam name="T">Collection type</typeparam>
     /// <param name="collection">Collection to restrict the number of items for</param>
     /// <param name="index">Position at where the item should be inserted</param>

--- a/ObservableCollection/MintPlayer.ObservableCollection.Extensions/ObservableCollectionExtensions.cs
+++ b/ObservableCollection/MintPlayer.ObservableCollection.Extensions/ObservableCollectionExtensions.cs
@@ -3,15 +3,33 @@
 public static class ObservableCollectionExtensions
 {
     /// <summary>
-    /// Only call this method on Add (when adding items at the end of the collection)
+    /// Ensure the collection have at most <paramref name="maxItemCount"/> items, exceeding items will be removed from the head of the collection.
     /// </summary>
-    private static void RemoveExceeding<T>(this ObservableCollection<T> collection, int maxItemCount)
+    /// <typeparam name="T"></typeparam>
+    /// <param name="collection"></param>
+    /// <param name="maxItemCount">The maximum number of items to keep in this <paramref name="collection"/>.</param>
+    private static void RemoveExceedingAtHead<T>(this ObservableCollection<T> collection, int maxItemCount)
     {
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxItemCount);
 
         var exceed = collection.Count - maxItemCount;
         if (exceed > 0)
             collection.RemoveRange(0, exceed);
+    }
+
+    /// <summary>
+    /// Ensure the collection have at most <paramref name="maxItemCount"/> items, exceeding items will be removed from the tail of the collection.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="collection"></param>
+    /// <param name="maxItemCount">The maximum number of items to keep in this <paramref name="collection"/>.</param>
+    private static void RemoveExceedingAtTail<T>(this ObservableCollection<T> collection, int maxItemCount)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxItemCount);
+
+        var exceed = collection.Count - maxItemCount;
+        if (exceed > 0)
+            collection.RemoveRange(maxItemCount, exceed);
     }
 
     public static void AddRange<T>(this ObservableCollection<T> collection, System.Collections.IEnumerable items)
@@ -22,19 +40,19 @@ public static class ObservableCollectionExtensions
     public static void AddRange<T>(this ObservableCollection<T> collection, System.Collections.IEnumerable items, int maxItemCount)
     {
         collection.AddRange(items.Cast<T>());
-        collection.RemoveExceeding(maxItemCount);
+        collection.RemoveExceedingAtHead(maxItemCount);
     }
 
     public static void AddRange<T>(this ObservableCollection<T> collection, IEnumerable<T> items, int maxItemCount)
     {
         collection.AddRange(items);
-        collection.RemoveExceeding(maxItemCount);
+        collection.RemoveExceedingAtHead(maxItemCount);
     }
 
     public static void Add<T>(this ObservableCollection<T> collection, T item, int maxItemCount)
     {
         collection.Add(item);
-        collection.RemoveExceeding(maxItemCount);
+        collection.RemoveExceedingAtHead(maxItemCount);
     }
 
     public static void RemoveRange<T>(this ObservableCollection<T> collection, System.Collections.IEnumerable items)
@@ -44,11 +62,20 @@ public static class ObservableCollectionExtensions
 
     public static void RemoveRange<T>(this ObservableCollection<T> collection, int start, int count)
     {
-        if (start < 0) throw new ArgumentOutOfRangeException(nameof(start), start, "Index can not be negative.");
-        if (count < 0) throw new ArgumentOutOfRangeException(nameof(count), count, "Count can not be negative.");
+        ArgumentOutOfRangeException.ThrowIfNegative(start);
+        ArgumentOutOfRangeException.ThrowIfNegative(count);
         if (count == 0) return;
         if (start >= collection.Count) throw new ArgumentOutOfRangeException(nameof(start), start, "The index is outside the range of this list.");
 
         collection.RemoveRange(collection.Skip(start).Take(count));
     }
+
+    public static void Insert<T>(this ObservableCollection<T> collection, int index, T item, int maxItemCount)
+    {
+        collection.Insert(index, item);
+        var halfCount = (collection.Count - 1) / 2;
+        if (index >= halfCount) collection.RemoveExceedingAtHead(maxItemCount);
+        else collection.RemoveExceedingAtTail(maxItemCount);
+    }
 }
+

--- a/ObservableCollection/MintPlayer.ObservableCollection.Extensions/ObservableCollectionExtensions.cs
+++ b/ObservableCollection/MintPlayer.ObservableCollection.Extensions/ObservableCollectionExtensions.cs
@@ -1,35 +1,32 @@
-﻿namespace MintPlayer.ObservableCollection.Extensions;
+﻿using MintPlayer.ObservableCollection.Extensions.Enums;
+
+namespace MintPlayer.ObservableCollection.Extensions;
 
 public static class ObservableCollectionExtensions
 {
     /// <summary>
-    /// Ensure the collection have at most <paramref name="maxItemCount"/> items, exceeding items will be removed from the head of the collection.
+    /// Ensure the collection have at most <paramref name="maxItemCount"/> items, exceeding items will be removed from the head/tail of the collection.
     /// </summary>
-    /// <typeparam name="T"></typeparam>
-    /// <param name="collection"></param>
+    /// <typeparam name="T">Collection type</typeparam>
+    /// <param name="collection">Collection to restrict the number of items for</param>
     /// <param name="maxItemCount">The maximum number of items to keep in this <paramref name="collection"/>.</param>
-    private static void RemoveExceedingAtHead<T>(this ObservableCollection<T> collection, int maxItemCount)
+    private static void RemoveExceedingAt<T>(this ObservableCollection<T> collection, int maxItemCount, ECollectionSide side)
     {
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxItemCount);
 
         var exceed = collection.Count - maxItemCount;
         if (exceed > 0)
-            collection.RemoveRange(0, exceed);
-    }
-
-    /// <summary>
-    /// Ensure the collection have at most <paramref name="maxItemCount"/> items, exceeding items will be removed from the tail of the collection.
-    /// </summary>
-    /// <typeparam name="T"></typeparam>
-    /// <param name="collection"></param>
-    /// <param name="maxItemCount">The maximum number of items to keep in this <paramref name="collection"/>.</param>
-    private static void RemoveExceedingAtTail<T>(this ObservableCollection<T> collection, int maxItemCount)
-    {
-        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxItemCount);
-
-        var exceed = collection.Count - maxItemCount;
-        if (exceed > 0)
-            collection.RemoveRange(maxItemCount, exceed);
+        {
+            switch (side)
+            {
+                case ECollectionSide.Head:
+                    collection.RemoveRange(0, exceed);
+                    break;
+                case ECollectionSide.Tail:
+                    collection.RemoveRange(maxItemCount, exceed);
+                    break;
+            }
+        }
     }
 
     public static void AddRange<T>(this ObservableCollection<T> collection, System.Collections.IEnumerable items)
@@ -40,19 +37,19 @@ public static class ObservableCollectionExtensions
     public static void AddRange<T>(this ObservableCollection<T> collection, System.Collections.IEnumerable items, int maxItemCount)
     {
         collection.AddRange(items.Cast<T>());
-        collection.RemoveExceedingAtHead(maxItemCount);
+        collection.RemoveExceedingAt(maxItemCount, ECollectionSide.Head);
     }
 
     public static void AddRange<T>(this ObservableCollection<T> collection, IEnumerable<T> items, int maxItemCount)
     {
         collection.AddRange(items);
-        collection.RemoveExceedingAtHead(maxItemCount);
+        collection.RemoveExceedingAt(maxItemCount, ECollectionSide.Head);
     }
 
     public static void Add<T>(this ObservableCollection<T> collection, T item, int maxItemCount)
     {
         collection.Add(item);
-        collection.RemoveExceedingAtHead(maxItemCount);
+        collection.RemoveExceedingAt(maxItemCount, ECollectionSide.Head);
     }
 
     public static void RemoveRange<T>(this ObservableCollection<T> collection, System.Collections.IEnumerable items)
@@ -76,17 +73,35 @@ public static class ObservableCollectionExtensions
     /// <remarks>
     /// If the <paramref name="index"/> is greater than or equal to the half of the collection count, exceeding items will be removed from the head of the collection, otherwise at the tail.
     /// </remarks>
-    /// <typeparam name="T"></typeparam>
-    /// <param name="collection"></param>
-    /// <param name="index"></param>
-    /// <param name="item"></param>
+    /// <typeparam name="T">Collection type</typeparam>
+    /// <param name="collection">Collection to restrict the number of items for</param>
+    /// <param name="index">Position at where the item should be inserted</param>
+    /// <param name="item">Item to insert</param>
     /// <param name="maxItemCount">The maximum number of items to keep in this <paramref name="collection"/>.</param>
     public static void Insert<T>(this ObservableCollection<T> collection, int index, T item, int maxItemCount)
     {
         collection.Insert(index, item);
         var halfCount = (collection.Count - 1) / 2;
-        if (index >= halfCount) collection.RemoveExceedingAtHead(maxItemCount);
-        else collection.RemoveExceedingAtTail(maxItemCount);
+        if (index >= halfCount) collection.RemoveExceedingAt(maxItemCount, ECollectionSide.Head);
+        else collection.RemoveExceedingAt(maxItemCount, ECollectionSide.Tail);
+    }
+
+    /// <summary>
+    /// Insert an item at the specified index, and ensure the collection have at most <paramref name="maxItemCount"/> items.
+    /// </summary>
+    /// <remarks>
+    /// If the <paramref name="index"/> is greater than or equal to the half of the collection count, exceeding items will be removed from the head of the collection, otherwise at the tail.
+    /// </remarks>
+    /// <typeparam name="T">Collection type</typeparam>
+    /// <param name="collection">Collection to restrict the number of items for</param>
+    /// <param name="index">Position at where the item should be inserted</param>
+    /// <param name="item">Item to insert</param>
+    /// <param name="maxItemCount">The maximum number of items to keep in this <paramref name="collection"/>.</param>
+    /// <param name="removeItemsAt">Whether to remove excessive items at the start/end of the collection</param>
+    public static void Insert<T>(this ObservableCollection<T> collection, int index, T item, int maxItemCount, ECollectionSide removeItemsAt)
+    {
+        collection.Insert(index, item);
+        collection.RemoveExceedingAt(maxItemCount, removeItemsAt);
     }
 }
 

--- a/ObservableCollection/MintPlayer.ObservableCollection.Extensions/ObservableCollectionExtensions.cs
+++ b/ObservableCollection/MintPlayer.ObservableCollection.Extensions/ObservableCollectionExtensions.cs
@@ -70,6 +70,17 @@ public static class ObservableCollectionExtensions
         collection.RemoveRange(collection.Skip(start).Take(count));
     }
 
+    /// <summary>
+    /// Insert an item at the specified index, and ensure the collection have at most <paramref name="maxItemCount"/> items.
+    /// </summary>
+    /// <remarks>
+    /// If the <paramref name="index"/> is greater than or equal to the half of the collection count, exceeding items will be removed from the head of the collection, otherwise at the tail.
+    /// </remarks>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="collection"></param>
+    /// <param name="index"></param>
+    /// <param name="item"></param>
+    /// <param name="maxItemCount">The maximum number of items to keep in this <paramref name="collection"/>.</param>
     public static void Insert<T>(this ObservableCollection<T> collection, int index, T item, int maxItemCount)
     {
         collection.Insert(index, item);

--- a/ObservableCollection/MintPlayer.ObservableCollection.Test/Program.cs
+++ b/ObservableCollection/MintPlayer.ObservableCollection.Test/Program.cs
@@ -11,8 +11,9 @@ namespace MintPlayer.ObservableCollection.Test
         static void Main(string[] args)
         {
             //Demo1();
-            Demo2();
+            //Demo2();
             //Demo3();
+            DemoMaxItemCount();
             Console.ReadKey();
         }
 
@@ -102,6 +103,31 @@ namespace MintPlayer.ObservableCollection.Test
                 new Person { FirstName = "Bill", LastName = "Belichick" },
             };
             col.AddRange(people);
+        }
+
+        private static void DemoMaxItemCount()
+        {
+            Console.WriteLine("MaxItemCount demo");
+            const int maxItemCount = 20;
+            var col = new ObservableCollection<int>();
+            col.AddRange(Enumerable.Range(0, maxItemCount));
+            Console.WriteLine(string.Join(", ", col));
+
+            // Should remove from head
+            col.Add(20, maxItemCount);
+            Console.WriteLine(string.Join(", ", col));
+
+            // Should remove from tail
+            col.Insert(1, 21, maxItemCount);
+            Console.WriteLine(string.Join(", ", col));
+
+            // Should remove from head
+            col.Insert(maxItemCount / 2, 22, maxItemCount);
+            Console.WriteLine(string.Join(", ", col));
+
+            // Should remove from tail
+            col.Insert(maxItemCount / 2 - 1, 23, maxItemCount);
+            Console.WriteLine(string.Join(", ", col));
         }
     }
 }

--- a/ObservableCollection/MintPlayer.ObservableCollection/ObservableCollection.cs
+++ b/ObservableCollection/MintPlayer.ObservableCollection/ObservableCollection.cs
@@ -51,7 +51,7 @@ namespace MintPlayer.ObservableCollection
                 OnCountPropertyChanged();
                 OnIndexerPropertyChanged();
                 OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, param.items));
-            }, new { items = items.ToList() });
+            }, new { items = items.ToArray() });
         }
 
         public virtual void RemoveRange(IEnumerable<T> items)
@@ -64,7 +64,7 @@ namespace MintPlayer.ObservableCollection
                 OnCountPropertyChanged();
                 OnIndexerPropertyChanged();
                 OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, param.items));
-            }, new { items = items.ToList() });
+            }, new { items = items.ToArray() });
         }
 
         #endregion Public methods


### PR DESCRIPTION
This is linked to #37

As you mention, I forgot about insert... As your library doesn't support `InsertRange` it makes it a little easy to guess, however it would work for range too.
My idea is to remove from head if you insert from half to end and remove from tail if you insert bellow half.

Check if you agree:

```C#
public static void Insert<T>(this ObservableCollection<T> collection, int index, T item, int maxItemCount)
{
    collection.Insert(index, item);
    var halfCount = (collection.Count - 1) / 2;
    if (index >= halfCount) collection.RemoveExceedingAtHead(maxItemCount);
    else collection.RemoveExceedingAtTail(maxItemCount);
}
```

Another complex idea would be having internal array to keep tracking of add index position order, but that would add overhead... I think this is best and simpler aproach.

Also, I still think having `MaxItemCount` property would be best, as that is set and forget, it would not require to change code for who wants a constrain of items.
For example, I use it for keep my graph and replies to a count, it's harder to ensure max items with extensions. Both could live into the library, I guess.