### PR TITLE
Fix ValueComparer dynamic helpers and add delegate caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -452,3 +452,6 @@ $RECYCLE.BIN/
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+
+# Claude Code
+.claude/settings.local.json

--- a/SourceGenerators/Mapper/MintPlayer.Mapper.Attributes/MintPlayer.Mapper.Attributes.csproj
+++ b/SourceGenerators/Mapper/MintPlayer.Mapper.Attributes/MintPlayer.Mapper.Attributes.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<LangVersion>14</LangVersion>
-		<Version>10.7.0</Version>
+		<Version>10.8.0</Version>
 		<Authors>Pieterjan De Clippel</Authors>
 		<Company>MintPlayer</Company>
 		<Description>This package contains attributes to automatically generate mappers</Description>

--- a/SourceGenerators/Mapper/MintPlayer.Mapper/MintPlayer.Mapper.csproj
+++ b/SourceGenerators/Mapper/MintPlayer.Mapper/MintPlayer.Mapper.csproj
@@ -11,7 +11,7 @@
 	</Target>
 
 	<PropertyGroup>
-		<Version>10.7.0</Version>
+		<Version>10.8.0</Version>
 		<Authors>Pieterjan De Clippel</Authors>
 		<Company>MintPlayer</Company>
 		<Description>This package automatically generates mappers for you</Description>

--- a/SourceGenerators/MintPlayer.SourceGenerators.Tools/MintPlayer.SourceGenerators.Tools.csproj
+++ b/SourceGenerators/MintPlayer.SourceGenerators.Tools/MintPlayer.SourceGenerators.Tools.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<Version>10.7.0</Version>
+		<Version>10.8.0</Version>
 		<Authors>Pieterjan De Clippel</Authors>
 		<Company>MintPlayer</Company>
 		<Description>This package contains useful tools for building source generators</Description>

--- a/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators.Attributes/MintPlayer.SourceGenerators.Attributes.csproj
+++ b/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators.Attributes/MintPlayer.SourceGenerators.Attributes.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<LangVersion>14</LangVersion>
-		<Version>10.7.0</Version>
+		<Version>10.8.0</Version>
 		<Authors>Pieterjan De Clippel</Authors>
 		<Company>MintPlayer</Company>
 		<Description>This package contains attributes for the source generators</Description>

--- a/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators/MintPlayer.SourceGenerators.csproj
+++ b/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators/MintPlayer.SourceGenerators.csproj
@@ -13,7 +13,7 @@
 	</Target>
 
 	<PropertyGroup>
-		<Version>10.7.0</Version>
+		<Version>10.8.0</Version>
 		<Authors>Pieterjan De Clippel</Authors>
 		<Company>MintPlayer</Company>
 		<Description>This package contains several source generators</Description>

--- a/SourceGenerators/ValueComparerGenerator/MintPlayer.ValueComparerGenerator.Attributes/MintPlayer.ValueComparerGenerator.Attributes.csproj
+++ b/SourceGenerators/ValueComparerGenerator/MintPlayer.ValueComparerGenerator.Attributes/MintPlayer.ValueComparerGenerator.Attributes.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<LangVersion>14</LangVersion>
-		<Version>10.7.0</Version>
+		<Version>10.8.0</Version>
 		<Authors>Pieterjan De Clippel</Authors>
 		<Company>MintPlayer</Company>
 		<Description>This package contains attributes for the ValueComparerGenerator</Description>

--- a/SourceGenerators/ValueComparerGenerator/MintPlayer.ValueComparerGenerator/MintPlayer.ValueComparerGenerator.csproj
+++ b/SourceGenerators/ValueComparerGenerator/MintPlayer.ValueComparerGenerator/MintPlayer.ValueComparerGenerator.csproj
@@ -12,7 +12,7 @@
 	</Target>
 
 	<PropertyGroup>
-		<Version>10.7.0</Version>
+		<Version>10.8.0</Version>
 		<Authors>Pieterjan De Clippel</Authors>
 		<Company>MintPlayer</Company>
 		<Description>This package contains a source generator that generates value-comparers for you</Description>

--- a/SourceGenerators/ValueComparers/MintPlayer.ValueComparers.NewtonsoftJson/MintPlayer.ValueComparers.NewtonsoftJson.csproj
+++ b/SourceGenerators/ValueComparers/MintPlayer.ValueComparers.NewtonsoftJson/MintPlayer.ValueComparers.NewtonsoftJson.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<Version>10.7.0</Version>
+		<Version>10.8.0</Version>
 		<Authors>Pieterjan De Clippel</Authors>
 		<Company>MintPlayer</Company>
 		<Description>This package contains useful tools for building source generators</Description>


### PR DESCRIPTION
## Summary
- Fix `AddDynamic` bug where `ref HashCodeCompat` lost ref semantics when passed through reflection `Invoke` (hash codes were being discarded)
- Add delegate caching for `ObjectEqualsDynamic` and `GetHashCodeDynamic` to avoid repeated `MakeGenericMethod` overhead
- Enhance `EqualsGeneric` and `GetHashCodeGeneric` to check `ComparerRegistry` first for consistency

## Test plan
- [x] Verify project compiles targeting .NET Standard 2.0
- [x] Verify downstream projects (e.g., `MintPlayer.ValueComparerGenerator`) build successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)