### PR TITLE
Auto-generate GeneratePathProperty for Attributes packages

### DIFF
--- a/SourceGenerators/Cli/MintPlayer.CliGenerator.Attributes/MintPlayer.CliGenerator.Attributes.csproj
+++ b/SourceGenerators/Cli/MintPlayer.CliGenerator.Attributes/MintPlayer.CliGenerator.Attributes.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<LangVersion>14</LangVersion>
-		<Version>10.8.0</Version>
+		<Version>10.9.0</Version>
 		<Authors>Pieterjan De Clippel</Authors>
 		<Company>MintPlayer</Company>
 		<Description>Attributes for building CLI command trees with the MintPlayer source generator infrastructure</Description>
@@ -22,6 +22,10 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
 		<PackageReference Include="System.CommandLine" Version="2.0.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<None Include="build\*.props" Pack="true" PackagePath="build" />
 	</ItemGroup>
 
 </Project>

--- a/SourceGenerators/Cli/MintPlayer.CliGenerator.Attributes/build/MintPlayer.CliGenerator.Attributes.props
+++ b/SourceGenerators/Cli/MintPlayer.CliGenerator.Attributes/build/MintPlayer.CliGenerator.Attributes.props
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<ItemGroup>
+		<PackageReference Update="MintPlayer.CliGenerator.Attributes" GeneratePathProperty="true" />
+	</ItemGroup>
+</Project>

--- a/SourceGenerators/Cli/MintPlayer.CliGenerator/MintPlayer.CliGenerator.csproj
+++ b/SourceGenerators/Cli/MintPlayer.CliGenerator/MintPlayer.CliGenerator.csproj
@@ -12,7 +12,7 @@
 	</Target>
 
 	<PropertyGroup>
-		<Version>10.8.0</Version>
+		<Version>10.9.0</Version>
 		<Authors>Pieterjan De Clippel</Authors>
 		<Company>MintPlayer</Company>
 		<Description>System.CommandLine command tree source generator with dependency injection helpers</Description>

--- a/SourceGenerators/Cli/MintPlayer.CliGenerator/build/MintPlayer.CliGenerator.targets
+++ b/SourceGenerators/Cli/MintPlayer.CliGenerator/build/MintPlayer.CliGenerator.targets
@@ -10,11 +10,6 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="CliGeneratorAttributes_CheckGeneratePathProperty" BeforeTargets="CoreCompile" Condition="'$(DesignTimeBuild)' != 'true'">
-    <Error Condition="'$(PkgMintPlayer_CliGenerator_Attributes)' == ''"
-           Text="Please add GeneratePathProperty=&quot;true&quot; on the MintPlayer.CliGenerator.Attributes PackageReference." />
-  </Target>
-
   <Target Name="MintPlayer_CliGenerator_TargetsLoaded" BeforeTargets="PrepareForBuild">
     <Message Text="MintPlayer.CliGenerator targets loaded" Importance="High" />
   </Target>

--- a/SourceGenerators/Mapper/MintPlayer.Mapper.Attributes/MintPlayer.Mapper.Attributes.csproj
+++ b/SourceGenerators/Mapper/MintPlayer.Mapper.Attributes/MintPlayer.Mapper.Attributes.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<LangVersion>14</LangVersion>
-		<Version>10.8.0</Version>
+		<Version>10.9.0</Version>
 		<Authors>Pieterjan De Clippel</Authors>
 		<Company>MintPlayer</Company>
 		<Description>This package contains attributes to automatically generate mappers</Description>
@@ -18,5 +18,9 @@
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 	</PropertyGroup>
+
+	<ItemGroup>
+		<None Include="build\*.props" Pack="true" PackagePath="build" />
+	</ItemGroup>
 
 </Project>

--- a/SourceGenerators/Mapper/MintPlayer.Mapper.Attributes/build/MintPlayer.Mapper.Attributes.props
+++ b/SourceGenerators/Mapper/MintPlayer.Mapper.Attributes/build/MintPlayer.Mapper.Attributes.props
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<ItemGroup>
+		<PackageReference Update="MintPlayer.Mapper.Attributes" GeneratePathProperty="true" />
+	</ItemGroup>
+</Project>

--- a/SourceGenerators/Mapper/MintPlayer.Mapper/MintPlayer.Mapper.csproj
+++ b/SourceGenerators/Mapper/MintPlayer.Mapper/MintPlayer.Mapper.csproj
@@ -11,7 +11,7 @@
 	</Target>
 
 	<PropertyGroup>
-		<Version>10.8.0</Version>
+		<Version>10.9.0</Version>
 		<Authors>Pieterjan De Clippel</Authors>
 		<Company>MintPlayer</Company>
 		<Description>This package automatically generates mappers for you</Description>

--- a/SourceGenerators/Mapper/MintPlayer.Mapper/build/MintPlayer.Mapper.targets
+++ b/SourceGenerators/Mapper/MintPlayer.Mapper/build/MintPlayer.Mapper.targets
@@ -17,17 +17,8 @@
 		</ItemGroup>
 	</Target>
 
-	<Target Name="MapperAttributes_CheckGeneratePathProperty" BeforeTargets="CoreCompile" Condition="'$(DesignTimeBuild)' != 'true'">
-		<Error Condition="'$(PkgMintPlayer_Mapper_Attributes)' == ''"
-			   Text="Please add GeneratePathProperty=&quot;true&quot; on the MintPlayer.Mapper.Attributes PackageReference." />
-	</Target>
-
 	<Target Name="MintPlayer_Mapper_TargetsLoaded" BeforeTargets="PrepareForBuild">
 		<Message Text="MintPlayer.Mapper targets loaded" Importance="High" />
-	</Target>
-
-	<Target Name="MintPlayer_Mapper_TargetsLoaded" BeforeTargets="PrepareForBuild">
-		<Message Text="Mapper targets loaded" Importance="High" />
 	</Target>
 
 </Project>

--- a/SourceGenerators/MintPlayer.SourceGenerators.Tools/MintPlayer.SourceGenerators.Tools.csproj
+++ b/SourceGenerators/MintPlayer.SourceGenerators.Tools/MintPlayer.SourceGenerators.Tools.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<Version>10.8.0</Version>
+		<Version>10.9.0</Version>
 		<Authors>Pieterjan De Clippel</Authors>
 		<Company>MintPlayer</Company>
 		<Description>This package contains useful tools for building source generators</Description>

--- a/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators.Attributes/MintPlayer.SourceGenerators.Attributes.csproj
+++ b/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators.Attributes/MintPlayer.SourceGenerators.Attributes.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<LangVersion>14</LangVersion>
-		<Version>10.8.0</Version>
+		<Version>10.9.0</Version>
 		<Authors>Pieterjan De Clippel</Authors>
 		<Company>MintPlayer</Company>
 		<Description>This package contains attributes for the source generators</Description>
@@ -21,6 +21,10 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<None Include="build\*.props" Pack="true" PackagePath="build" />
 	</ItemGroup>
 
 </Project>

--- a/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators.Attributes/build/MintPlayer.SourceGenerators.Attributes.props
+++ b/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators.Attributes/build/MintPlayer.SourceGenerators.Attributes.props
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<ItemGroup>
+		<PackageReference Update="MintPlayer.SourceGenerators.Attributes" GeneratePathProperty="true" />
+	</ItemGroup>
+</Project>

--- a/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators/MintPlayer.SourceGenerators.csproj
+++ b/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators/MintPlayer.SourceGenerators.csproj
@@ -13,7 +13,7 @@
 	</Target>
 
 	<PropertyGroup>
-		<Version>10.8.0</Version>
+		<Version>10.9.0</Version>
 		<Authors>Pieterjan De Clippel</Authors>
 		<Company>MintPlayer</Company>
 		<Description>This package contains several source generators</Description>

--- a/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators/build/MintPlayer.SourceGenerators.targets
+++ b/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators/build/MintPlayer.SourceGenerators.targets
@@ -16,11 +16,6 @@
 		</ItemGroup>
     </Target>
 
-	<Target Name="SourceGeneratorAttributes_CheckGeneratePathProperty" BeforeTargets="CoreCompile" Condition="'$(DesignTimeBuild)' != 'true'">
-		<Error Condition="'$(PkgMintPlayer_SourceGenerators_Attributes)' == ''"
-			   Text="Please add GeneratePathProperty=&quot;true&quot; on the MintPlayer.SourceGenerators.Attributes PackageReference." />
-	</Target>
-
 	<Target Name="MintPlayer_SourceGenerators_TargetsLoaded" BeforeTargets="PrepareForBuild">
 		<Message Text="MintPlayer.SourceGenerators targets loaded" Importance="High" />
 	</Target>

--- a/SourceGenerators/ValueComparerGenerator/MintPlayer.ValueComparerGenerator.Attributes/MintPlayer.ValueComparerGenerator.Attributes.csproj
+++ b/SourceGenerators/ValueComparerGenerator/MintPlayer.ValueComparerGenerator.Attributes/MintPlayer.ValueComparerGenerator.Attributes.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<LangVersion>14</LangVersion>
-		<Version>10.8.0</Version>
+		<Version>10.9.0</Version>
 		<Authors>Pieterjan De Clippel</Authors>
 		<Company>MintPlayer</Company>
 		<Description>This package contains attributes for the ValueComparerGenerator</Description>
@@ -18,5 +18,9 @@
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 	</PropertyGroup>
+
+	<ItemGroup>
+		<None Include="build\*.props" Pack="true" PackagePath="build" />
+	</ItemGroup>
 
 </Project>

--- a/SourceGenerators/ValueComparerGenerator/MintPlayer.ValueComparerGenerator.Attributes/build/MintPlayer.ValueComparerGenerator.Attributes.props
+++ b/SourceGenerators/ValueComparerGenerator/MintPlayer.ValueComparerGenerator.Attributes/build/MintPlayer.ValueComparerGenerator.Attributes.props
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<ItemGroup>
+		<PackageReference Update="MintPlayer.ValueComparerGenerator.Attributes" GeneratePathProperty="true" />
+	</ItemGroup>
+</Project>

--- a/SourceGenerators/ValueComparerGenerator/MintPlayer.ValueComparerGenerator/MintPlayer.ValueComparerGenerator.csproj
+++ b/SourceGenerators/ValueComparerGenerator/MintPlayer.ValueComparerGenerator/MintPlayer.ValueComparerGenerator.csproj
@@ -12,7 +12,7 @@
 	</Target>
 
 	<PropertyGroup>
-		<Version>10.8.0</Version>
+		<Version>10.9.0</Version>
 		<Authors>Pieterjan De Clippel</Authors>
 		<Company>MintPlayer</Company>
 		<Description>This package contains a source generator that generates value-comparers for you</Description>

--- a/SourceGenerators/ValueComparerGenerator/MintPlayer.ValueComparerGenerator/build/MintPlayer.ValueComparerGenerator.targets
+++ b/SourceGenerators/ValueComparerGenerator/MintPlayer.ValueComparerGenerator/build/MintPlayer.ValueComparerGenerator.targets
@@ -17,11 +17,6 @@
         </ItemGroup>
     </Target>
 
-	<Target Name="ValueComparerGeneratorAttributes_CheckGeneratePathProperty" BeforeTargets="CoreCompile" Condition="'$(DesignTimeBuild)' != 'true'">
-		<Error Condition="'$(PkgMintPlayer_ValueComparerGenerator_Attributes)' == ''"
-			   Text="Please add GeneratePathProperty=&quot;true&quot; on the MintPlayer.ValueComparerGenerator.Attributes PackageReference." />
-	</Target>
-
 	<Target Name="MintPlayer_ValueComparerGenerator_TargetsLoaded" BeforeTargets="PrepareForBuild">
 		<Message Text="MintPlayer.ValueComparerGenerator targets loaded" Importance="High" />
 	</Target>

--- a/SourceGenerators/ValueComparers/MintPlayer.ValueComparers.NewtonsoftJson/MintPlayer.ValueComparers.NewtonsoftJson.csproj
+++ b/SourceGenerators/ValueComparers/MintPlayer.ValueComparers.NewtonsoftJson/MintPlayer.ValueComparers.NewtonsoftJson.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<Version>10.8.0</Version>
+		<Version>10.9.0</Version>
 		<Authors>Pieterjan De Clippel</Authors>
 		<Company>MintPlayer</Company>
 		<Description>This package contains useful tools for building source generators</Description>


### PR DESCRIPTION
## Summary
- Consumers no longer need to manually add `GeneratePathProperty="true"` to Attributes package references
- Added `build/*.props` files to each Attributes package that automatically set `GeneratePathProperty="true"` via MSBuild Update
- Removed the error-checking targets from main generator packages (no longer needed)
- Bumped all source generator packages to version 10.9.0

## Affected Packages
- MintPlayer.CliGenerator / MintPlayer.CliGenerator.Attributes
- MintPlayer.Mapper / MintPlayer.Mapper.Attributes
- MintPlayer.SourceGenerators / MintPlayer.SourceGenerators.Attributes
- MintPlayer.ValueComparerGenerator / MintPlayer.ValueComparerGenerator.Attributes
- MintPlayer.SourceGenerators.Tools
- MintPlayer.ValueComparers.NewtonsoftJson

## Test plan
- [ ] Build all source generator packages
- [ ] Create a test project referencing the Attributes packages without `GeneratePathProperty="true"`
- [ ] Verify that `$(PkgMintPlayer_*_Attributes)` properties are automatically available

🤖 Generated with [Claude Code](https://claude.com/claude-code)