### PR TITLE
Add PathSpec support to source generators and bump version to 10.10.0

### DIFF
--- a/SourceGenerators/Cli/MintPlayer.CliGenerator.Attributes/MintPlayer.CliGenerator.Attributes.csproj
+++ b/SourceGenerators/Cli/MintPlayer.CliGenerator.Attributes/MintPlayer.CliGenerator.Attributes.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<LangVersion>14</LangVersion>
-		<Version>10.9.0</Version>
+		<Version>10.10.0</Version>
 		<Authors>Pieterjan De Clippel</Authors>
 		<Company>MintPlayer</Company>
 		<Description>Attributes for building CLI command trees with the MintPlayer source generator infrastructure</Description>

--- a/SourceGenerators/Cli/MintPlayer.CliGenerator/MintPlayer.CliGenerator.csproj
+++ b/SourceGenerators/Cli/MintPlayer.CliGenerator/MintPlayer.CliGenerator.csproj
@@ -12,7 +12,7 @@
 	</Target>
 
 	<PropertyGroup>
-		<Version>10.9.0</Version>
+		<Version>10.10.0</Version>
 		<Authors>Pieterjan De Clippel</Authors>
 		<Company>MintPlayer</Company>
 		<Description>System.CommandLine command tree source generator with dependency injection helpers</Description>

--- a/SourceGenerators/Mapper/MintPlayer.Mapper.Attributes/MintPlayer.Mapper.Attributes.csproj
+++ b/SourceGenerators/Mapper/MintPlayer.Mapper.Attributes/MintPlayer.Mapper.Attributes.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<LangVersion>14</LangVersion>
-		<Version>10.9.0</Version>
+		<Version>10.10.0</Version>
 		<Authors>Pieterjan De Clippel</Authors>
 		<Company>MintPlayer</Company>
 		<Description>This package contains attributes to automatically generate mappers</Description>

--- a/SourceGenerators/Mapper/MintPlayer.Mapper/MintPlayer.Mapper.csproj
+++ b/SourceGenerators/Mapper/MintPlayer.Mapper/MintPlayer.Mapper.csproj
@@ -11,7 +11,7 @@
 	</Target>
 
 	<PropertyGroup>
-		<Version>10.9.0</Version>
+		<Version>10.10.0</Version>
 		<Authors>Pieterjan De Clippel</Authors>
 		<Company>MintPlayer</Company>
 		<Description>This package automatically generates mappers for you</Description>

--- a/SourceGenerators/MintPlayer.SourceGenerators.Tools/MintPlayer.SourceGenerators.Tools.csproj
+++ b/SourceGenerators/MintPlayer.SourceGenerators.Tools/MintPlayer.SourceGenerators.Tools.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<Version>10.9.0</Version>
+		<Version>10.10.0</Version>
 		<Authors>Pieterjan De Clippel</Authors>
 		<Company>MintPlayer</Company>
 		<Description>This package contains useful tools for building source generators</Description>

--- a/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators.Attributes/MintPlayer.SourceGenerators.Attributes.csproj
+++ b/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators.Attributes/MintPlayer.SourceGenerators.Attributes.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<LangVersion>14</LangVersion>
-		<Version>10.9.0</Version>
+		<Version>10.10.0</Version>
 		<Authors>Pieterjan De Clippel</Authors>
 		<Company>MintPlayer</Company>
 		<Description>This package contains attributes for the source generators</Description>

--- a/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators/Generators/GenericMethodSourceGenerator.Producer.cs
+++ b/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators/Generators/GenericMethodSourceGenerator.Producer.cs
@@ -22,7 +22,10 @@ public class GenericMethodProducer : Producer
             {
                 writer.WriteLine(Header);
                 writer.WriteLine();
-                using (writer.OpenBlock($"namespace {RootNamespace}"))
+                var ns = method.Method.PathSpec?.ContainingNamespace ?? method.Method.ContainingNamespace ?? RootNamespace;
+                IDisposableWriterIndent? namespaceBlock = string.IsNullOrEmpty(ns) ? null : writer.OpenBlock($"namespace {ns}");
+
+                using (writer.OpenPathSpec(method.Method.PathSpec))
                 {
                     writer.Write("public ");
                     if (method.Method.ClassModifiers.Any(Microsoft.CodeAnalysis.CSharp.SyntaxKind.StaticKeyword)) writer.Write("static ");
@@ -59,6 +62,8 @@ public class GenericMethodProducer : Producer
                         }
                     }
                 }
+
+                namespaceBlock?.Dispose();
             }
         }
     }

--- a/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators/Generators/GenericMethodSourceGenerator.cs
+++ b/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators/Generators/GenericMethodSourceGenerator.cs
@@ -43,6 +43,7 @@ public class GenericMethodSourceGenerator : IncrementalGenerator
 
                         if (attributeSyntax is { Attribute.ArgumentList.Arguments.Count: > 0 } && int.TryParse(attributeSyntax.Attribute.ArgumentList.Arguments[0].Expression.ToFullString(), out var countValue))
                         {
+                            var pathSpec = classSymbol.GetPathSpec(ct);
                             return new Models.GenericMethodDeclaration
                             {
                                 Method = new Models.MethodDeclaration
@@ -51,12 +52,13 @@ public class GenericMethodSourceGenerator : IncrementalGenerator
                                     ClassName = classSymbol.Name,
                                     MethodModifiers = methodDeclaration.Modifiers,
                                     ClassModifiers = classDeclaration.Modifiers,
-                                    ContainingNamespace = classSymbol.ContainingNamespace.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+                                    ContainingNamespace = pathSpec?.ContainingNamespace,
+                                    PathSpec = pathSpec,
                                     //ClassIsPartial = classDeclaration.Modifiers.Any(SyntaxKind.PartialKeyword),
                                     //MethodIsPartial = methodDeclaration.Modifiers.Any(SyntaxKind.PartialKeyword),
                                     //ClassIsStatic = classDeclaration.Modifiers.Any(SyntaxKind.StaticKeyword),
                                     //MethodIsStatic = methodDeclaration.Modifiers.Any(SyntaxKind.StaticKeyword),
-                                    //GenericMethodAttribute = 
+                                    //GenericMethodAttribute =
                                 },
                                 Count = countValue,
                             };

--- a/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators/Generators/InjectSourceGenerator.Producer.cs
+++ b/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators/Generators/InjectSourceGenerator.Producer.cs
@@ -17,37 +17,39 @@ internal class InjectProducer : Producer
 
     protected override void ProduceSource(IndentedTextWriter writer, CancellationToken cancellationToken)
     {
-        foreach (var classInfoNamespace in classInfos.GroupBy(ci => ci.ClassNamespace ?? RootNamespace))
+        foreach (var classInfoNamespace in classInfos.GroupBy(ci => ci.PathSpec?.ContainingNamespace ?? ci.ClassNamespace ?? RootNamespace))
         {
-            using (writer.OpenBlock($"namespace {classInfoNamespace.Key}"))
+            IDisposableWriterIndent? namespaceBlock = string.IsNullOrEmpty(classInfoNamespace.Key) ? null : writer.OpenBlock($"namespace {classInfoNamespace.Key}");
+
+            foreach (var classInfo in classInfoNamespace)
             {
-                foreach (var classInfo in classInfoNamespace)
+                var constructorParams = classInfo.InjectFields
+                    .Concat(classInfo.BaseDependencies)
+                    .Select(dep => $"{dep.Type} {dep.Name}")
+                    .Distinct()
+                    .ToList();
+
+                if (!constructorParams.Any()) continue;
+
+                var assignments = classInfo.InjectFields.Select(dep => $"this.{dep.Name} = {dep.Name};");
+                var baseConstructorArgs = classInfo.BaseDependencies.Select(dep => dep.Name).Distinct();
+
+                using (writer.OpenPathSpec(classInfo.PathSpec))
+                using (writer.OpenBlock($"partial class {classInfo.ClassName}"))
                 {
-                    var constructorParams = classInfo.InjectFields
-                        .Concat(classInfo.BaseDependencies)
-                        .Select(dep => $"{dep.Type} {dep.Name}")
-                        .Distinct()
-                        .ToList();
+                    writer.WriteLine($"public {classInfo.ClassName}({string.Join(", ", constructorParams)})");
+                    if (baseConstructorArgs.Any())
+                        writer.IndentSingleLine(baseConstructorArgs.Any() ? $": base({string.Join(", ", baseConstructorArgs)})" : string.Empty);
 
-                    if (!constructorParams.Any()) continue;
-
-                    var assignments = classInfo.InjectFields.Select(dep => $"this.{dep.Name} = {dep.Name};");
-                    var baseConstructorArgs = classInfo.BaseDependencies.Select(dep => dep.Name).Distinct();
-
-                    using (writer.OpenBlock($"partial class {classInfo.ClassName}"))
+                    using (writer.OpenBlock(string.Empty))
                     {
-                        writer.WriteLine($"public {classInfo.ClassName}({string.Join(", ", constructorParams)})");
-                        if (baseConstructorArgs.Any())
-                            writer.IndentSingleLine(baseConstructorArgs.Any() ? $": base({string.Join(", ", baseConstructorArgs)})" : string.Empty);
-
-                        using (writer.OpenBlock(string.Empty))
-                        {
-                            foreach (var assignment in assignments)
-                                writer.WriteLine(assignment);
-                        }
+                        foreach (var assignment in assignments)
+                            writer.WriteLine(assignment);
                     }
                 }
             }
+
+            namespaceBlock?.Dispose();
         }
     }
 }

--- a/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators/Generators/InjectSourceGenerator.cs
+++ b/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators/Generators/InjectSourceGenerator.cs
@@ -42,6 +42,8 @@ public class InjectSourceGenerator : IncrementalGenerator
 
                         if (currentType is INamedTypeSymbol currentTypeSymbol)
                         {
+                            var pathSpec = currentTypeSymbol.GetPathSpec(ct);
+
                             while (currentTypeSymbol?.BaseType != null && currentTypeSymbol.BaseType.SpecialType != SpecialType.System_Object)
                             {
                                 var baseTypeSyntax = currentTypeSymbol.BaseType.DeclaringSyntaxReferences
@@ -53,13 +55,12 @@ public class InjectSourceGenerator : IncrementalGenerator
                                 currentTypeSymbol = currentTypeSymbol.BaseType;
                             }
 
-                            var namespaceDeclaration = classDeclaration.FirstAncestorOrSelf<BaseNamespaceDeclarationSyntax>();
-
                             return new Models.ClassWithBaseDependenciesAndInjectFields
                             {
                                 FileName = classDeclaration.Identifier.Text,
                                 ClassName = className,
-                                ClassNamespace = namespaceDeclaration?.Name?.ToString(),
+                                ClassNamespace = pathSpec?.ContainingNamespace,
+                                PathSpec = pathSpec,
                                 BaseDependencies = baseDependencies,
                                 InjectFields = injectFields,
                             };

--- a/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators/MintPlayer.SourceGenerators.csproj
+++ b/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators/MintPlayer.SourceGenerators.csproj
@@ -13,7 +13,7 @@
 	</Target>
 
 	<PropertyGroup>
-		<Version>10.9.0</Version>
+		<Version>10.10.0</Version>
 		<Authors>Pieterjan De Clippel</Authors>
 		<Company>MintPlayer</Company>
 		<Description>This package contains several source generators</Description>

--- a/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators/Models/ClassWithBaseDependenciesAndInjectFields.cs
+++ b/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators/Models/ClassWithBaseDependenciesAndInjectFields.cs
@@ -1,4 +1,5 @@
-﻿using MintPlayer.ValueComparerGenerator.Attributes;
+﻿using MintPlayer.SourceGenerators.Tools;
+using MintPlayer.ValueComparerGenerator.Attributes;
 
 namespace MintPlayer.SourceGenerators.Models;
 
@@ -8,6 +9,7 @@ public partial class ClassWithBaseDependenciesAndInjectFields
     public string FileName { get; set; } = string.Empty;
     public string ClassName { get; set; } = string.Empty;
     public string? ClassNamespace { get; set; } = string.Empty;
+    public PathSpec? PathSpec { get; set; }
     public IList<InjectField> BaseDependencies { get; set; } = [];
     public IList<InjectField> InjectFields { get; set; } = [];
 }

--- a/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators/Models/MethodDeclaration.cs
+++ b/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators/Models/MethodDeclaration.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.CodeAnalysis;
+using MintPlayer.SourceGenerators.Tools;
 using MintPlayer.ValueComparerGenerator.Attributes;
 
 namespace MintPlayer.SourceGenerators.Models;
@@ -9,6 +10,7 @@ public partial class MethodDeclaration
     public string? MethodName { get; set; }
     public string? ClassName { get; set; }
     public string? ContainingNamespace { get; set; }
+    public PathSpec? PathSpec { get; set; }
     public SyntaxTokenList MethodModifiers { get; set; }
     public SyntaxTokenList ClassModifiers { get; set; }
     //public bool ClassIsPartial { get; set; }

--- a/SourceGenerators/ValueComparerGenerator/MintPlayer.ValueComparerGenerator.Attributes/MintPlayer.ValueComparerGenerator.Attributes.csproj
+++ b/SourceGenerators/ValueComparerGenerator/MintPlayer.ValueComparerGenerator.Attributes/MintPlayer.ValueComparerGenerator.Attributes.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<LangVersion>14</LangVersion>
-		<Version>10.9.0</Version>
+		<Version>10.10.0</Version>
 		<Authors>Pieterjan De Clippel</Authors>
 		<Company>MintPlayer</Company>
 		<Description>This package contains attributes for the ValueComparerGenerator</Description>

--- a/SourceGenerators/ValueComparerGenerator/MintPlayer.ValueComparerGenerator/MintPlayer.ValueComparerGenerator.csproj
+++ b/SourceGenerators/ValueComparerGenerator/MintPlayer.ValueComparerGenerator/MintPlayer.ValueComparerGenerator.csproj
@@ -12,7 +12,7 @@
 	</Target>
 
 	<PropertyGroup>
-		<Version>10.9.0</Version>
+		<Version>10.10.0</Version>
 		<Authors>Pieterjan De Clippel</Authors>
 		<Company>MintPlayer</Company>
 		<Description>This package contains a source generator that generates value-comparers for you</Description>

--- a/SourceGenerators/ValueComparers/MintPlayer.ValueComparers.NewtonsoftJson/MintPlayer.ValueComparers.NewtonsoftJson.csproj
+++ b/SourceGenerators/ValueComparers/MintPlayer.ValueComparers.NewtonsoftJson/MintPlayer.ValueComparers.NewtonsoftJson.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<Version>10.9.0</Version>
+		<Version>10.10.0</Version>
 		<Authors>Pieterjan De Clippel</Authors>
 		<Company>MintPlayer</Company>
 		<Description>This package contains useful tools for building source generators</Description>


### PR DESCRIPTION
## Summary
- Add `PathSpec` to `InjectSourceGenerator` and `GenericMethodSourceGenerator` to capture the complete namespace and nested type hierarchy
- Update producers to use `OpenPathSpec()` for proper nested type reconstruction, ensuring Visual Studio/.NET properly recognizes symbols across generated files
- Bump all source generator package versions from 10.9.0 to 10.10.0

## Changes
### InjectSourceGenerator
- Added `PathSpec` property to `ClassWithBaseDependenciesAndInjectFields` model
- Updated generator to capture PathSpec using `symbol.GetPathSpec(ct)`
- Updated producer to use `OpenPathSpec()` instead of simple namespace blocks

### GenericMethodSourceGenerator
- Added `PathSpec` property to `MethodDeclaration` model
- Updated generator to capture PathSpec
- Updated producer to use `OpenPathSpec()` and proper namespace from PathSpec

### Version Bump
Updated all 10 source generator packages to version 10.10.0:
- MintPlayer.CliGenerator.Attributes
- MintPlayer.CliGenerator
- MintPlayer.Mapper.Attributes
- MintPlayer.Mapper
- MintPlayer.SourceGenerators.Attributes
- MintPlayer.SourceGenerators
- MintPlayer.SourceGenerators.Tools
- MintPlayer.ValueComparerGenerator.Attributes
- MintPlayer.ValueComparerGenerator
- MintPlayer.ValueComparers.NewtonsoftJson

## Test plan
- [ ] Verify InjectSourceGenerator correctly generates nested partial classes
- [ ] Verify GenericMethodSourceGenerator correctly generates nested partial classes
- [ ] Build all source generator projects successfully
- [ ] Test with a project using nested partial classes with `[Inject]` attribute

🤖 Generated with [Claude Code](https://claude.com/claude-code)