### PR TITLE
Fix CliGenerator namespace consistency and bump version to 10.10.1

### DIFF
--- a/SourceGenerators/Cli/MintPlayer.CliGenerator.Attributes/MintPlayer.CliGenerator.Attributes.csproj
+++ b/SourceGenerators/Cli/MintPlayer.CliGenerator.Attributes/MintPlayer.CliGenerator.Attributes.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<LangVersion>14</LangVersion>
-		<Version>10.10.0</Version>
+		<Version>10.10.1</Version>
 		<Authors>Pieterjan De Clippel</Authors>
 		<Company>MintPlayer</Company>
 		<Description>Attributes for building CLI command trees with the MintPlayer source generator infrastructure</Description>

--- a/SourceGenerators/Cli/MintPlayer.CliGenerator/MintPlayer.CliGenerator.csproj
+++ b/SourceGenerators/Cli/MintPlayer.CliGenerator/MintPlayer.CliGenerator.csproj
@@ -12,7 +12,7 @@
 	</Target>
 
 	<PropertyGroup>
-		<Version>10.10.0</Version>
+		<Version>10.10.1</Version>
 		<Authors>Pieterjan De Clippel</Authors>
 		<Company>MintPlayer</Company>
 		<Description>System.CommandLine command tree source generator with dependency injection helpers</Description>

--- a/SourceGenerators/Mapper/MintPlayer.Mapper.Attributes/MintPlayer.Mapper.Attributes.csproj
+++ b/SourceGenerators/Mapper/MintPlayer.Mapper.Attributes/MintPlayer.Mapper.Attributes.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<LangVersion>14</LangVersion>
-		<Version>10.10.0</Version>
+		<Version>10.10.1</Version>
 		<Authors>Pieterjan De Clippel</Authors>
 		<Company>MintPlayer</Company>
 		<Description>This package contains attributes to automatically generate mappers</Description>

--- a/SourceGenerators/Mapper/MintPlayer.Mapper/MintPlayer.Mapper.csproj
+++ b/SourceGenerators/Mapper/MintPlayer.Mapper/MintPlayer.Mapper.csproj
@@ -11,7 +11,7 @@
 	</Target>
 
 	<PropertyGroup>
-		<Version>10.10.0</Version>
+		<Version>10.10.1</Version>
 		<Authors>Pieterjan De Clippel</Authors>
 		<Company>MintPlayer</Company>
 		<Description>This package automatically generates mappers for you</Description>

--- a/SourceGenerators/MintPlayer.SourceGenerators.Tools/MintPlayer.SourceGenerators.Tools.csproj
+++ b/SourceGenerators/MintPlayer.SourceGenerators.Tools/MintPlayer.SourceGenerators.Tools.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<Version>10.10.0</Version>
+		<Version>10.10.1</Version>
 		<Authors>Pieterjan De Clippel</Authors>
 		<Company>MintPlayer</Company>
 		<Description>This package contains useful tools for building source generators</Description>

--- a/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators.Attributes/MintPlayer.SourceGenerators.Attributes.csproj
+++ b/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators.Attributes/MintPlayer.SourceGenerators.Attributes.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<LangVersion>14</LangVersion>
-		<Version>10.10.0</Version>
+		<Version>10.10.1</Version>
 		<Authors>Pieterjan De Clippel</Authors>
 		<Company>MintPlayer</Company>
 		<Description>This package contains attributes for the source generators</Description>

--- a/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators/MintPlayer.SourceGenerators.csproj
+++ b/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators/MintPlayer.SourceGenerators.csproj
@@ -13,7 +13,7 @@
 	</Target>
 
 	<PropertyGroup>
-		<Version>10.10.0</Version>
+		<Version>10.10.1</Version>
 		<Authors>Pieterjan De Clippel</Authors>
 		<Company>MintPlayer</Company>
 		<Description>This package contains several source generators</Description>

--- a/SourceGenerators/ValueComparerGenerator/MintPlayer.ValueComparerGenerator.Attributes/MintPlayer.ValueComparerGenerator.Attributes.csproj
+++ b/SourceGenerators/ValueComparerGenerator/MintPlayer.ValueComparerGenerator.Attributes/MintPlayer.ValueComparerGenerator.Attributes.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<LangVersion>14</LangVersion>
-		<Version>10.10.0</Version>
+		<Version>10.10.1</Version>
 		<Authors>Pieterjan De Clippel</Authors>
 		<Company>MintPlayer</Company>
 		<Description>This package contains attributes for the ValueComparerGenerator</Description>

--- a/SourceGenerators/ValueComparerGenerator/MintPlayer.ValueComparerGenerator/MintPlayer.ValueComparerGenerator.csproj
+++ b/SourceGenerators/ValueComparerGenerator/MintPlayer.ValueComparerGenerator/MintPlayer.ValueComparerGenerator.csproj
@@ -12,7 +12,7 @@
 	</Target>
 
 	<PropertyGroup>
-		<Version>10.10.0</Version>
+		<Version>10.10.1</Version>
 		<Authors>Pieterjan De Clippel</Authors>
 		<Company>MintPlayer</Company>
 		<Description>This package contains a source generator that generates value-comparers for you</Description>

--- a/SourceGenerators/ValueComparers/MintPlayer.ValueComparers.NewtonsoftJson/MintPlayer.ValueComparers.NewtonsoftJson.csproj
+++ b/SourceGenerators/ValueComparers/MintPlayer.ValueComparers.NewtonsoftJson/MintPlayer.ValueComparers.NewtonsoftJson.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<Version>10.10.0</Version>
+		<Version>10.10.1</Version>
 		<Authors>Pieterjan De Clippel</Authors>
 		<Company>MintPlayer</Company>
 		<Description>This package contains useful tools for building source generators</Description>


### PR DESCRIPTION
## Summary

- Fix inconsistent namespace handling in `CliCommandSourceGenerator`
- Generate partial classes in symbol's actual namespace (required by C#)
- Generate extension methods in `RootNamespace` (consistent with other generators)
- Bump all source generator package versions from 10.10.0 to 10.10.1

## Problem

Previously, the CLI generator would put both partial classes and extension methods in the same namespace, falling back to `RootNamespace` when the symbol was in global namespace. This caused compilation errors because:

1. A partial class **must** be in the same namespace as the original declaration
2. When a command was declared in global namespace but `RootNamespace` was set (e.g., `ConsoleApp30`), the generated partial class would be in a different namespace than the original

## Solution

- **Partial classes**: Now use the symbol's actual namespace (global or named)
- **Extension methods**: Always generated in `RootNamespace` for consistency with other generators like `ServiceRegistrationsGenerator` and `MapperGenerator`

## Example

For a command declared in **global namespace** with `RootNamespace = ConsoleApp30`:

```csharp
// Partial classes - global namespace (matches original declaration)
public partial class DemoCommand
{
    internal static void RegisterCliCommandTree(...) { ... }
}

// Extension methods - RootNamespace (discoverable, consistent)
namespace ConsoleApp30
{
    public static class DemoCommandCliExtensions
    {
        public static IServiceCollection AddDemoCommand(...) { ... }
    }
}
```

## Breaking Change

Projects that previously relied on extension methods being in the symbol's namespace will need to add `using {RootNamespace};` to access the extension methods.

## Test Plan

- [x] Build `ConsoleApp30` test project (command in global namespace)
- [x] Build `CliCommandDebugging` test project (command in named namespace)
- [x] Full solution build passes with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)