### PR TITLE
Add customizable service registration method name

### DIFF
--- a/SourceGenerators/Mapper/MintPlayer.Mapper/Generators/MapperGenerator.Producer.cs
+++ b/SourceGenerators/Mapper/MintPlayer.Mapper/Generators/MapperGenerator.Producer.cs
@@ -257,7 +257,7 @@ public sealed class MapperProducer : Producer, IDiagnosticReporter
         {
             if (source.PropertyType != destination.PropertyType)
                 writer.WriteLine($"{prefix}ConvertProperty<{destination.PropertyType}, {source.PropertyType}>(input.{destination.PropertyName}){suffix}");
-            else if (source.StateName != null && destination.StateName != null)
+            else if (source.StateName is not null && destination.StateName is not null)
                 writer.WriteLine($"""{prefix}ConvertProperty<{destination.PropertyType}, {source.PropertyType}>(input.{destination.PropertyName}, {source.StateName}, {destination.StateName}){suffix}""");
             else
                 writer.WriteLine($"{prefix}input.{destination.PropertyName}{suffix}");

--- a/SourceGenerators/MintPlayer.SourceGenerators.Tools/Extensions/TypeExtensions.cs
+++ b/SourceGenerators/MintPlayer.SourceGenerators.Tools/Extensions/TypeExtensions.cs
@@ -6,7 +6,7 @@ internal static class TypeExtensions
     {
         var objectType = typeof(object);
         //while (!type.OneOf([objectType, null]))
-        while (type != objectType && type != null)
+        while (type is not null && type != objectType)
         {
             var cur = type!.IsGenericType ? type.GetGenericTypeDefinition() : type;
 

--- a/SourceGenerators/MintPlayer.SourceGenerators.Tools/Polyfills/HashCodeCompat.cs
+++ b/SourceGenerators/MintPlayer.SourceGenerators.Tools/Polyfills/HashCodeCompat.cs
@@ -11,7 +11,7 @@ namespace MintPlayer.SourceGenerators.Tools.Polyfills
 
         public void Add<T>(T value, IEqualityComparer<T>? comparer) =>
             _hash = Combine(_hash,
-                comparer != null ? comparer.GetHashCode(value!) :
+                comparer is not null ? comparer.GetHashCode(value!) :
                 value?.GetHashCode() ?? 0);
 
         public static int Combine(int h1, int h2)

--- a/SourceGenerators/README.md
+++ b/SourceGenerators/README.md
@@ -117,26 +117,43 @@ public partial class TestService
 - Works with inheritance (each class can have its own)
 
 ## Service registration
-Similarily, for the first snippet, the `[Register]` attribute generates the following code for you:
+Similarly, for the first snippet, the `[Register]` attribute generates the following code for you:
 
 ```csharp
-
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Demo
 {
     public static class DependencyInjectionExtensionMethods
     {
-        public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddServices(this global::Microsoft.Extensions.DependencyInjection.IServiceCollection services)
+        public static global::Microsoft.Extensions.DependencyInjection.IServiceCollection AddDemo(this global::Microsoft.Extensions.DependencyInjection.IServiceCollection services)
         {
             return services
-                .AddScoped<global::MintPlayer.Spark.ITestServiceBaseBase, global::MintPlayer.Spark.TestServiceBaseBase>()
-                .AddScoped<global::MintPlayer.Spark.ITestServiceBase, global::MintPlayer.Spark.TestServiceBase>()
-                .AddScoped<global::MintPlayer.Spark.ITestService, global::MintPlayer.Spark.TestService>();
+                .AddScoped<global::Demo.ITestServiceBaseBase, global::Demo.TestServiceBaseBase>()
+                .AddScoped<global::Demo.ITestServiceBase, global::Demo.TestServiceBase>()
+                .AddScoped<global::Demo.ITestService, global::Demo.TestService>();
         }
     }
 }
 ```
 
-Now you can call this generated `.AddServices()` method on any service collection in your application.
-You can change the name of this method by adding the desired name as parameter to the `[Register]` attribute.
+### Method Name Resolution
+
+The generated method name is determined by (in order of precedence):
+
+1. **Explicit hint** on `[Register]` attribute: `[Register(typeof(IService), ServiceLifetime.Scoped, "MyServices")]` → `AddMyServices()`
+2. **Assembly-level configuration**: `[assembly: ServiceRegistrationConfiguration(DefaultMethodName = "CoreServices")]` → `AddCoreServices()`
+3. **Assembly name** (default): Assembly `MyCompany.Demo` → `AddMyCompanyDemo()`
+
+### Assembly-Level Configuration
+
+Configure defaults for all service registrations in your assembly:
+
+```csharp
+using MintPlayer.SourceGenerators.Attributes;
+
+[assembly: ServiceRegistrationConfiguration(
+    DefaultMethodName = "MyServices",
+    DefaultAccessibility = EGeneratedAccessibility.Internal
+)]
+```

--- a/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators.Attributes/MintPlayer.SourceGenerators.Attributes.csproj
+++ b/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators.Attributes/MintPlayer.SourceGenerators.Attributes.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<LangVersion>14</LangVersion>
-		<Version>10.13.0</Version>
+		<Version>10.15.0</Version>
 		<Authors>Pieterjan De Clippel</Authors>
 		<Company>MintPlayer</Company>
 		<Description>This package contains attributes for the source generators</Description>

--- a/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators.Attributes/ServiceRegistrationConfigurationAttribute.cs
+++ b/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators.Attributes/ServiceRegistrationConfigurationAttribute.cs
@@ -1,0 +1,26 @@
+#nullable enable
+
+namespace MintPlayer.SourceGenerators.Attributes;
+
+/// <summary>
+/// Configures the default service registration method name at the assembly level.
+/// </summary>
+/// <remarks>
+/// Use this attribute to override the default method name for generated service registration extension methods.
+/// When not specified, the method name defaults to "Add{AssemblyName}".
+/// </remarks>
+[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false)]
+public class ServiceRegistrationConfigurationAttribute : Attribute
+{
+    /// <summary>
+    /// Gets or sets the default method name for the generated service registration extension method.
+    /// If not specified, the method name defaults to "Add{AssemblyName}".
+    /// The "Add" prefix will be automatically added if not present.
+    /// </summary>
+    public string? DefaultMethodName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the default accessibility of the generated extension method.
+    /// </summary>
+    public EGeneratedAccessibility DefaultAccessibility { get; set; } = EGeneratedAccessibility.Unspecified;
+}

--- a/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators/Diagnostics/InterfaceImplementationAnalyzer.Codefix.cs
+++ b/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators/Diagnostics/InterfaceImplementationAnalyzer.Codefix.cs
@@ -25,7 +25,7 @@ public class InterfaceCodeFixProvider : CodeFixProvider
 
         // Locate the class declaration
         var classDecl = classSyntaxRoot?.FindToken(diagnosticSpan.Start).Parent?.AncestorsAndSelf().OfType<ClassDeclarationSyntax>().First();
-        if (classDecl == null)
+        if (classDecl is null)
             return;
 
         context.RegisterCodeFix(
@@ -47,17 +47,17 @@ public class InterfaceCodeFixProvider : CodeFixProvider
 
         var classSymbol = classSemanticModel.GetDeclaredSymbol(classDeclaration, cancellationToken);
         var interfaceSymbol = classSymbol?.Interfaces.FirstOrDefault();
-        if (interfaceSymbol == null) return solution;
+        if (interfaceSymbol is null) return solution;
 
         var interfaceFirstLocation = interfaceSymbol.Locations[0];
         var interfaceDocument = solution.Projects
             .SelectMany(p => p.Documents)
             .FirstOrDefault(d => d.FilePath == interfaceFirstLocation.SourceTree?.FilePath);
-        if (interfaceDocument == null) return solution;
+        if (interfaceDocument is null) return solution;
 
         var interfaceSyntaxRoot = await interfaceDocument.GetSyntaxRootAsync(cancellationToken);
         var interfaceSemanticModel = await interfaceDocument.GetSemanticModelAsync(cancellationToken);
-        if (interfaceSyntaxRoot == null || interfaceSemanticModel == null) return solution;
+        if (interfaceSyntaxRoot is null || interfaceSemanticModel is null) return solution;
 
         // Determine missing members
         var classMembers = classSymbol?.GetMembers().Where(m => (m.DeclaredAccessibility == Accessibility.Public) && !m.IsStatic && !m.IsImplicitlyDeclared);
@@ -72,7 +72,7 @@ public class InterfaceCodeFixProvider : CodeFixProvider
         var interfaceNode = interfaceSyntaxRoot.DescendantNodes()
             .OfType<InterfaceDeclarationSyntax>()
             .FirstOrDefault(i => SymbolEqualityComparer.Default.Equals(interfaceSemanticModel.GetDeclaredSymbol(i, cancellationToken), interfaceSymbol));
-        if (interfaceNode == null) return solution;
+        if (interfaceNode is null) return solution;
 
         // Add missing members to the interface
         var updatedInterfaceNode = interfaceNode.AddMembers(missingMembers.ToArray());

--- a/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators/Diagnostics/UnusedUsingsAnalyzer.CodeFix.cs
+++ b/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators/Diagnostics/UnusedUsingsAnalyzer.CodeFix.cs
@@ -20,7 +20,7 @@ public class UnusedUsingsCodeFixProvider : CodeFixProvider
     {
         var diagnostic = context.Diagnostics[0];
         var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
-        if (root == null) return;
+        if (root is null) return;
 
         var node = root.FindNode(diagnostic.Location.SourceSpan);
         if (node is not UsingDirectiveSyntax) return;
@@ -36,7 +36,7 @@ public class UnusedUsingsCodeFixProvider : CodeFixProvider
     private static async Task<Document> RemoveAllUnusedUsings(Document document, ImmutableArray<Diagnostic> diagnostics, CancellationToken cancellationToken)
     {
         var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-        if (root == null) return document;
+        if (root is null) return document;
 
         // Find all unused using nodes
         var usingDirectives = diagnostics

--- a/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators/Generators/ServiceRegistrationsGenerator.Producer.cs
+++ b/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators/Generators/ServiceRegistrationsGenerator.Producer.cs
@@ -10,6 +10,9 @@ namespace MintPlayer.SourceGenerators.Generators;
 
 public class RegistrationsProducer : Producer
 {
+    private const string MethodPrefix = "Add";
+    private const string DefaultMethodNameFallback = "Services";
+
     private readonly IEnumerable<ServiceRegistration> serviceRegistrations;
     private readonly bool knowsDependencyInjectionAbstractions;
     private readonly AssemblyRegistrationConfig assemblyConfig;
@@ -50,7 +53,7 @@ public class RegistrationsProducer : Producer
                             ?? SanitizeAssemblyName(assemblyConfig.AssemblyName);
 
                         // Enforce "Add" prefix
-                        methodName = methodName.StartsWith("Add") ? methodName : $"Add{methodName}";
+                        methodName = methodName.StartsWith(MethodPrefix) ? methodName : $"{MethodPrefix}{methodName}";
 
                         // Resolve accessibility with precedence: explicit registration > assembly config > default (Public)
                         var accessibility = methodGroup.Select(m => m.Accessibility).Where(a => a is not EGeneratedAccessibility.Unspecified).ToArray() is { Length: > 0 } items
@@ -272,7 +275,7 @@ public class RegistrationsProducer : Producer
     private static string SanitizeAssemblyName(string assemblyName)
     {
         if (string.IsNullOrEmpty(assemblyName))
-            return "Services";
+            return DefaultMethodNameFallback;
 
         // Split by dots, capitalize each part, join
         var parts = assemblyName.Split('.')
@@ -293,6 +296,6 @@ public class RegistrationsProducer : Producer
         if (sanitized.Length > 0 && char.IsDigit(sanitized[0]))
             sanitized.Insert(0, '_');
 
-        return sanitized.Length > 0 ? sanitized.ToString() : "Services";
+        return sanitized.Length > 0 ? sanitized.ToString() : DefaultMethodNameFallback;
     }
 }

--- a/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators/Generators/ServiceRegistrationsGenerator.cs
+++ b/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators/Generators/ServiceRegistrationsGenerator.cs
@@ -145,9 +145,9 @@ public class ServiceRegistrationsGenerator : IncrementalGenerator
                 string? defaultMethodName = null;
                 var defaultAccessibility = EGeneratedAccessibility.Unspecified;
 
-                if (configAttr != null)
+                if (configAttr is { NamedArguments: { } namedArguments })
                 {
-                    foreach (var namedArg in configAttr.NamedArguments)
+                    foreach (var namedArg in namedArguments)
                     {
                         if (namedArg.Key == nameof(ServiceRegistrationConfigurationAttribute.DefaultMethodName))
                             defaultMethodName = namedArg.Value.Value as string;

--- a/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators/Generators/ServiceRegistrationsGenerator.cs
+++ b/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators/Generators/ServiceRegistrationsGenerator.cs
@@ -140,7 +140,7 @@ public class ServiceRegistrationsGenerator : IncrementalGenerator
             {
                 var assemblyName = compilation.Assembly.Name;
                 var configAttr = compilation.Assembly.GetAttributes()
-                    .FirstOrDefault(a => a.AttributeClass?.Name == "ServiceRegistrationConfigurationAttribute");
+                    .FirstOrDefault(a => a.AttributeClass?.Name == nameof(ServiceRegistrationConfigurationAttribute));
 
                 string? defaultMethodName = null;
                 var defaultAccessibility = EGeneratedAccessibility.Unspecified;
@@ -149,9 +149,9 @@ public class ServiceRegistrationsGenerator : IncrementalGenerator
                 {
                     foreach (var namedArg in configAttr.NamedArguments)
                     {
-                        if (namedArg.Key == "DefaultMethodName")
+                        if (namedArg.Key == nameof(ServiceRegistrationConfigurationAttribute.DefaultMethodName))
                             defaultMethodName = namedArg.Value.Value as string;
-                        else if (namedArg.Key == "DefaultAccessibility")
+                        else if (namedArg.Key == nameof(ServiceRegistrationConfigurationAttribute.DefaultAccessibility))
                             defaultAccessibility = (EGeneratedAccessibility)(int)namedArg.Value.Value!;
                     }
                 }

--- a/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators/MintPlayer.SourceGenerators.csproj
+++ b/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators/MintPlayer.SourceGenerators.csproj
@@ -13,7 +13,7 @@
 	</Target>
 
 	<PropertyGroup>
-		<Version>10.14.1</Version>
+		<Version>10.15.0</Version>
 		<Authors>Pieterjan De Clippel</Authors>
 		<Company>MintPlayer</Company>
 		<Description>This package contains several source generators</Description>

--- a/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators/Models/AssemblyRegistrationConfig.cs
+++ b/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators/Models/AssemblyRegistrationConfig.cs
@@ -1,0 +1,27 @@
+using MintPlayer.SourceGenerators.Attributes;
+using MintPlayer.ValueComparerGenerator.Attributes;
+
+namespace MintPlayer.SourceGenerators.Models;
+
+/// <summary>
+/// Holds assembly-level configuration for service registration generation.
+/// </summary>
+[AutoValueComparer]
+public partial class AssemblyRegistrationConfig
+{
+    /// <summary>
+    /// The name of the assembly being processed.
+    /// </summary>
+    public string AssemblyName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The default method name configured via ServiceRegistrationConfigurationAttribute.
+    /// Null if not specified.
+    /// </summary>
+    public string? DefaultMethodName { get; set; }
+
+    /// <summary>
+    /// The default accessibility configured via ServiceRegistrationConfigurationAttribute.
+    /// </summary>
+    public EGeneratedAccessibility DefaultAccessibility { get; set; } = EGeneratedAccessibility.Unspecified;
+}


### PR DESCRIPTION
## Summary

- Add `ServiceRegistrationConfigurationAttribute` for assembly-level configuration of default method name and accessibility
- Add `AssemblyRegistrationConfig` model to hold assembly settings
- Update `ServiceRegistrationsGenerator` to extract assembly configuration
- Change default method name from `AddServices` to `Add{AssemblyName}` (e.g., `AddMintPlayerSourceGeneratorsDebug`)
- Method name resolution follows precedence: explicit hint > assembly config > assembly name
- Bump package versions to 10.15.0

## Usage

The default behavior now generates method names based on the assembly name:
```csharp
// Assembly: MyCompany.Services.Core
// Generated method: AddMyCompanyServicesCore()
```

To customize at assembly level:
```csharp
[assembly: ServiceRegistrationConfiguration(DefaultMethodName = "MyServices")]
// Generated method: AddMyServices()
```

Explicit hints on `[Register]` still take precedence:
```csharp
[Register(typeof(IMyService), ServiceLifetime.Scoped, "CoreServices")]
// Generated method: AddCoreServices()
```

## Test plan

- [x] Build the solution successfully
- [x] Verify generated code uses assembly name when no hint provided
- [x] Verify explicit method hints still work as expected
- [x] Verify full solution builds with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)