### PR TITLE
feat: Add solve CLI tool for delegating GitHub issues to Claude Code

### DIFF
--- a/Solve/Commands/FeedbackCommand.cs
+++ b/Solve/Commands/FeedbackCommand.cs
@@ -1,0 +1,139 @@
+using MintPlayer.CliGenerator.Attributes;
+using MintPlayer.SourceGenerators.Attributes;
+using Solve.Services;
+
+namespace Solve.Commands;
+
+[CliCommand("feedback", Description = "Review and resolve PR feedback")]
+[CliParentCommand(typeof(SolveCommand))]
+public partial class FeedbackCommand : ICliCommand
+{
+    [Inject] private readonly IConsoleService _console;
+    [Inject] private readonly IGitService _git;
+    [Inject] private readonly IGitHubService _github;
+    [Inject] private readonly IClaudeService _claude;
+
+    [CliArgument(0, Name = "pr-url", Required = false, Description = "PR URL or number (detects from branch if omitted)"), NoInterfaceMember]
+    public string? PrUrl { get; set; }
+
+    [CliOption("--assess-only", Description = "Only show assessment, don't implement"), NoInterfaceMember]
+    public bool AssessOnly { get; set; }
+
+    public async Task<int> Execute(CancellationToken cancellationToken)
+    {
+        // Check prerequisites
+        if (!await _github.IsInstalledAsync(cancellationToken))
+        {
+            _console.WriteGhInstallInstructions();
+            return 1;
+        }
+
+        if (!await _github.IsAuthenticatedAsync(cancellationToken))
+        {
+            _console.WriteGhAuthInstructions();
+            return 1;
+        }
+
+        // Get PR info
+        var pr = await _github.GetPullRequestForBranchAsync(cancellationToken);
+
+        if (!pr.HasValue && string.IsNullOrEmpty(PrUrl))
+        {
+            _console.WriteError("Error: No PR found for current branch.");
+            _console.WriteLine("Please provide a PR URL/number or ensure you're on a branch with an open PR.");
+            return 1;
+        }
+
+        var prNumber = pr?.Number ?? 0;
+        var prTitle = pr?.Title ?? "Unknown";
+
+        if (!string.IsNullOrEmpty(PrUrl))
+        {
+            // Parse PR URL/number
+            if (int.TryParse(PrUrl.TrimStart('#'), out var parsedNumber))
+            {
+                prNumber = parsedNumber;
+            }
+            else if (PrUrl.Contains("/pull/"))
+            {
+                var parts = PrUrl.Split("/pull/");
+                if (parts.Length > 1 && int.TryParse(parts[1].Split('/')[0], out var urlNumber))
+                {
+                    prNumber = urlNumber;
+                }
+            }
+        }
+
+        if (prNumber == 0)
+        {
+            _console.WriteError("Error: Could not determine PR number.");
+            return 1;
+        }
+
+        _console.WriteInfo($"Fetching feedback for PR #{prNumber}...");
+
+        // Get repo info
+        var (owner, repo) = await _git.GetRemoteInfoAsync(cancellationToken);
+
+        if (owner == null || repo == null)
+        {
+            _console.WriteError("Error: Could not determine repository info.");
+            return 1;
+        }
+
+        // Fetch review threads
+        var reviewData = await _github.GetPullRequestReviewsAsync(owner, repo, prNumber, cancellationToken);
+
+        if (string.IsNullOrEmpty(reviewData))
+        {
+            _console.WriteWarning("No review feedback found or unable to fetch reviews.");
+            _console.WriteLine("This could mean:");
+            _console.WriteLine("  - The PR has no reviews yet");
+            _console.WriteLine("  - All review threads are resolved");
+            _console.WriteLine("  - There was an error fetching the data");
+            return 0;
+        }
+
+        _console.WriteHeader($"\n## PR #{prNumber}: {prTitle}");
+        _console.WriteLine();
+        _console.WriteLine("Review feedback data retrieved.");
+        _console.WriteLine();
+
+        if (AssessOnly)
+        {
+            _console.WriteLine("Review data (raw):");
+            _console.WriteLine(reviewData);
+            return 0;
+        }
+
+        // Launch Claude to help process the feedback
+        if (await _claude.IsAvailableAsync(cancellationToken))
+        {
+            var prompt = $"""
+                You are helping to resolve PR feedback for PR #{prNumber}.
+
+                Here is the review data from GitHub:
+                {reviewData}
+
+                Please analyze the unresolved review threads and:
+                1. Summarize each unresolved comment/change request
+                2. Assess whether each is valid, partially valid, or not valid
+                3. Create a development plan for addressing valid feedback
+                4. Implement the necessary changes
+
+                Focus only on unresolved threads (where isResolved is false).
+                """;
+
+            _console.WriteInfo("Launching Claude Code to help resolve feedback...");
+            await _claude.LaunchWithPromptAsync(prompt, cancellationToken);
+        }
+        else
+        {
+            _console.WriteWarning("Claude CLI not found.");
+            _console.WriteLine("Please review the feedback manually:");
+            _console.WriteLine(reviewData);
+        }
+
+        return 0;
+    }
+}

--- a/Solve/Commands/InitCommand.cs
+++ b/Solve/Commands/InitCommand.cs
@@ -1,0 +1,131 @@
+using MintPlayer.CliGenerator.Attributes;
+using MintPlayer.SourceGenerators.Attributes;
+using Solve.Models;
+using Solve.Services;
+
+namespace Solve.Commands;
+
+[CliCommand("init", Description = "Initialize branch for an issue")]
+[CliParentCommand(typeof(SolveCommand))]
+public partial class InitCommand : ICliCommand
+{
+    [Inject] private readonly IConsoleService _console;
+    [Inject] private readonly IGitService _git;
+    [Inject] private readonly IGitHubService _github;
+
+    [CliArgument(0, Name = "issue-url", Description = "GitHub issue URL or reference"), NoInterfaceMember]
+    public string IssueUrl { get; set; } = string.Empty;
+
+    [CliOption("--branch-prefix", "-p", Description = "Branch prefix", DefaultValue = "issues"), NoInterfaceMember]
+    public string BranchPrefix { get; set; } = "issues";
+
+    [CliOption("--no-pull", Description = "Skip git pull"), NoInterfaceMember]
+    public bool NoPull { get; set; }
+
+    [CliOption("--force", Description = "Create new branch even if one exists"), NoInterfaceMember]
+    public bool Force { get; set; }
+
+    public async Task<int> Execute(CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(IssueUrl))
+        {
+            _console.WriteError("Error: Issue URL or reference is required.");
+            _console.WriteLine("Usage: solve init <issue-url>");
+            return 1;
+        }
+
+        // Check prerequisites
+        if (!await _github.IsInstalledAsync(cancellationToken))
+        {
+            _console.WriteGhInstallInstructions();
+            return 1;
+        }
+
+        if (!await _github.IsAuthenticatedAsync(cancellationToken))
+        {
+            _console.WriteGhAuthInstructions();
+            return 1;
+        }
+
+        // Parse issue reference
+        var (owner, repo) = await _git.GetRemoteInfoAsync(cancellationToken);
+        var issueRef = IssueReference.Parse(IssueUrl, owner, repo);
+
+        if (issueRef == null)
+        {
+            _console.WriteError($"Error: Could not parse issue reference: {IssueUrl}");
+            return 1;
+        }
+
+        // Fetch issue details
+        _console.WriteInfo($"Fetching issue #{issueRef.Number}...");
+        var issue = issueRef.Owner != null && issueRef.Repo != null
+            ? await _github.GetIssueAsync(issueRef.Owner, issueRef.Repo, issueRef.Number, cancellationToken)
+            : await _github.GetIssueAsync(issueRef.Number, cancellationToken);
+
+        if (issue == null)
+        {
+            _console.WriteError($"Error: Could not fetch issue #{issueRef.Number}");
+            return 1;
+        }
+
+        _console.WriteLine($"  Title: {issue.Title}");
+        if (issue.Labels.Count > 0)
+            _console.WriteLine($"  Labels: {string.Join(", ", issue.Labels)}");
+
+        // Check for existing branch
+        var branchName = $"{BranchPrefix}/{issue.Number}-{issue.GetSlug()}";
+        var existingBranches = await _git.FindBranchesAsync($"{BranchPrefix}/{issue.Number}", cancellationToken);
+
+        if (existingBranches.Count > 0 && !Force)
+        {
+            _console.WriteWarning($"Found existing branch(es) for issue #{issue.Number}:");
+            foreach (var branch in existingBranches)
+            {
+                _console.WriteLine($"  - {branch}");
+            }
+
+            if (_console.Confirm("Switch to existing branch?"))
+            {
+                var targetBranch = existingBranches[0];
+                await _git.FetchAsync(cancellationToken);
+                await _git.CheckoutAsync(targetBranch, cancellationToken);
+                _console.WriteSuccess($"Switched to branch: {targetBranch}");
+                return 0;
+            }
+            else if (!_console.Confirm("Create a new branch anyway?"))
+            {
+                return 1;
+            }
+        }
+
+        // Switch to default branch
+        var defaultBranch = await _git.GetDefaultBranchAsync(cancellationToken);
+        _console.WriteInfo($"Switching to default branch ({defaultBranch})...");
+        await _git.CheckoutAsync(defaultBranch!, cancellationToken);
+
+        // Pull latest (unless skipped)
+        if (!NoPull)
+        {
+            _console.WriteInfo("Pulling latest changes...");
+            await _git.PullAsync(cancellationToken);
+        }
+
+        // Create feature branch
+        _console.WriteInfo($"Creating branch: {branchName}");
+        var created = await _git.CreateBranchAsync(branchName, cancellationToken);
+
+        if (!created)
+        {
+            _console.WriteError($"Error: Failed to create branch '{branchName}'");
+            return 1;
+        }
+
+        _console.WriteSuccess($"\nBranch '{branchName}' created and checked out.");
+        _console.WriteLine("\nNext steps:");
+        _console.WriteLine("  solve prd       - Generate PRD and development plan");
+        _console.WriteLine("  solve work      - Start working with Claude Code");
+
+        return 0;
+    }
+}

--- a/Solve/Commands/PrCommand.cs
+++ b/Solve/Commands/PrCommand.cs
@@ -1,0 +1,459 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using MintPlayer.CliGenerator.Attributes;
+using MintPlayer.SourceGenerators.Attributes;
+using Solve.Models;
+using Solve.Services;
+
+namespace Solve.Commands;
+
+[CliCommand("pr", Description = "Create a pull request for the current issue")]
+[CliParentCommand(typeof(SolveCommand))]
+public partial class PrCommand : ICliCommand
+{
+    /// <summary>
+    /// Standard locations for PR templates (in order of precedence).
+    /// </summary>
+    private static readonly string[] PrTemplateLocations =
+    [
+        ".github/PULL_REQUEST_TEMPLATE.md",
+        ".github/pull_request_template.md",
+        ".github/PULL_REQUEST_TEMPLATE/default.md",
+        ".github/PULL_REQUEST_TEMPLATE/pull_request_template.md",
+        "docs/PULL_REQUEST_TEMPLATE.md",
+        "docs/pull_request_template.md",
+        "PULL_REQUEST_TEMPLATE.md",
+        "pull_request_template.md"
+    ];
+
+    /// <summary>
+    /// Paths to check in the organization's .github repository.
+    /// </summary>
+    private static readonly string[] OrgTemplateLocations =
+    [
+        ".github/PULL_REQUEST_TEMPLATE.md",
+        ".github/pull_request_template.md",
+        "PULL_REQUEST_TEMPLATE.md",
+        "pull_request_template.md"
+    ];
+
+    [Inject] private readonly IConsoleService _console;
+    [Inject] private readonly IGitService _git;
+    [Inject] private readonly IGitHubService _github;
+
+    [CliArgument(0, Name = "issue-url", Required = false, Description = "GitHub issue URL or reference (detects from branch if omitted)"), NoInterfaceMember]
+    public string? IssueUrl { get; set; }
+
+    [CliOption("--draft", "-d", Description = "Create as draft PR"), NoInterfaceMember]
+    public bool Draft { get; set; }
+
+    [CliOption("--base", "-b", Description = "Target branch (default: auto-detect)"), NoInterfaceMember]
+    public string? BaseBranch { get; set; }
+
+    [CliOption("--title", "-t", Description = "Custom PR title (default: issue title)"), NoInterfaceMember]
+    public string? Title { get; set; }
+
+    [CliOption("--no-checklist", Description = "Skip pre-PR checklist"), NoInterfaceMember]
+    public bool NoChecklist { get; set; }
+
+    [CliOption("--yes", "-y", Description = "Skip confirmation"), NoInterfaceMember]
+    public bool SkipConfirmation { get; set; }
+
+    [CliOption("--no-template", Description = "Ignore repository PR template, use built-in"), NoInterfaceMember]
+    public bool NoTemplate { get; set; }
+
+    public async Task<int> Execute(CancellationToken cancellationToken)
+    {
+        // Check prerequisites
+        if (!await _github.IsInstalledAsync(cancellationToken))
+        {
+            _console.WriteGhInstallInstructions();
+            return 1;
+        }
+
+        if (!await _github.IsAuthenticatedAsync(cancellationToken))
+        {
+            _console.WriteGhAuthInstructions();
+            return 1;
+        }
+
+        // Check for existing PR
+        var existingPr = await _github.GetPullRequestForBranchAsync(cancellationToken);
+        if (existingPr.HasValue)
+        {
+            _console.WriteWarning($"A PR already exists for this branch:");
+            _console.WriteLine($"  #{existingPr.Value.Number} - {existingPr.Value.Title}");
+            _console.WriteLine($"  {existingPr.Value.Url}");
+            return 1;
+        }
+
+        var (owner, repo) = await _git.GetRemoteInfoAsync(cancellationToken);
+        var currentBranch = await _git.GetCurrentBranchAsync(cancellationToken);
+        int? issueNumber = null;
+
+        // Try to get issue number from argument or branch
+        if (!string.IsNullOrEmpty(IssueUrl))
+        {
+            var issueRef = IssueReference.Parse(IssueUrl, owner, repo);
+            issueNumber = issueRef?.Number;
+        }
+        else if (!string.IsNullOrEmpty(currentBranch))
+        {
+            issueNumber = IssueReference.ExtractFromBranchName(currentBranch);
+        }
+
+        if (!issueNumber.HasValue)
+        {
+            _console.WriteError("Error: Could not determine issue number.");
+            _console.WriteLine("Please provide an issue URL/reference or ensure you're on an issue branch.");
+            return 1;
+        }
+
+        // Pre-PR checklist
+        if (!NoChecklist)
+        {
+            _console.WriteHeader("\nPre-PR Checklist:");
+
+            if (!_console.Confirm("Have you tested your changes locally?"))
+            {
+                _console.WriteError("Please test your changes before creating a PR.");
+                return 1;
+            }
+
+            if (!_console.Confirm("Are there no uncommitted changes you want to include?"))
+            {
+                _console.WriteError("Please commit or stash your changes before creating a PR.");
+                return 1;
+            }
+        }
+
+        // Fetch issue details
+        var issue = owner != null && repo != null
+            ? await _github.GetIssueAsync(owner, repo, issueNumber.Value, cancellationToken)
+            : await _github.GetIssueAsync(issueNumber.Value, cancellationToken);
+
+        var prTitle = Title ?? issue?.Title ?? $"Fix issue #{issueNumber}";
+
+        // Determine base branch
+        var baseBranch = BaseBranch ?? await _git.GetDefaultBranchAsync(cancellationToken) ?? "main";
+
+        // Get commit log and diff for description
+        var commitLog = await _git.GetLogAsync(baseBranch, "HEAD", cancellationToken);
+        var diff = await _git.GetDiffAsync(baseBranch, "HEAD", cancellationToken);
+
+        // Determine PR type based on branch and labels
+        var prType = DeterminePrType(currentBranch, issue?.Labels ?? []);
+
+        // Generate PR body - check for repository template first, then org template
+        string prBody;
+        string? templateContent = null;
+        string? templateSource = null;
+
+        if (!NoTemplate)
+        {
+            // First, check for local repository template
+            var localTemplatePath = FindLocalPrTemplate();
+            if (localTemplatePath != null)
+            {
+                templateSource = localTemplatePath;
+                templateContent = await File.ReadAllTextAsync(localTemplatePath, cancellationToken);
+            }
+            // Then, check for organization .github repository template
+            else if (owner != null)
+            {
+                var (orgTemplateContent, orgTemplatePath) = await FindOrgPrTemplateAsync(owner, cancellationToken);
+                if (orgTemplateContent != null)
+                {
+                    templateSource = $"{owner}/.github/{orgTemplatePath}";
+                    templateContent = orgTemplateContent;
+                }
+            }
+        }
+
+        if (templateContent != null && templateSource != null)
+        {
+            _console.WriteInfo($"Using PR template: {templateSource}");
+            prBody = ProcessPrTemplate(templateContent, issueNumber.Value, prType, commitLog, issue);
+        }
+        else
+        {
+            prBody = GeneratePrBody(issueNumber.Value, prType, commitLog, diff);
+        }
+
+        // Show preview
+        _console.WriteHeader("\n=== PR Preview ===");
+        _console.WriteLine($"Title: {prTitle}");
+        _console.WriteLine($"Base: {baseBranch}");
+        _console.WriteLine($"Head: {currentBranch}");
+        if (Draft)
+            _console.WriteLine("Draft: Yes");
+        _console.WriteLine();
+        _console.WriteLine("Body:");
+        _console.WriteLine(prBody);
+        _console.WriteLine("=== End Preview ===\n");
+
+        if (!SkipConfirmation && !_console.Confirm("Create this PR?"))
+        {
+            _console.WriteLine("PR creation cancelled.");
+            return 1;
+        }
+
+        // Push branch
+        _console.WriteInfo("Pushing branch to remote...");
+        var pushed = await _git.PushAsync(setUpstream: true, cancellationToken);
+        if (!pushed)
+        {
+            _console.WriteError("Error: Failed to push branch.");
+            return 1;
+        }
+
+        // Create PR
+        _console.WriteInfo("Creating pull request...");
+        var prUrl = await _github.CreatePullRequestAsync(prTitle, prBody, baseBranch, Draft, cancellationToken);
+
+        if (string.IsNullOrEmpty(prUrl))
+        {
+            _console.WriteError("Error: Failed to create pull request.");
+            return 1;
+        }
+
+        _console.WriteSuccess($"\nPull request created: {prUrl}");
+
+        return 0;
+    }
+
+    private static string DeterminePrType(string? branchName, List<string> labels)
+    {
+        var labelSet = new HashSet<string>(labels.Select(l => l.ToLowerInvariant()));
+
+        if (labelSet.Contains("bug") || labelSet.Contains("bugfix"))
+            return "Bug Fix";
+        if (labelSet.Contains("documentation") || labelSet.Contains("docs"))
+            return "Documentation Update";
+        if (labelSet.Contains("refactor"))
+            return "Code Refactor";
+        if (labelSet.Contains("test") || labelSet.Contains("testing"))
+            return "Test";
+
+        if (branchName != null)
+        {
+            var branch = branchName.ToLowerInvariant();
+            if (branch.Contains("fix") || branch.Contains("bug"))
+                return "Bug Fix";
+            if (branch.Contains("doc"))
+                return "Documentation Update";
+            if (branch.Contains("refactor"))
+                return "Code Refactor";
+            if (branch.Contains("test"))
+                return "Test";
+        }
+
+        return "Feature";
+    }
+
+    private static string GeneratePrBody(int issueNumber, string prType, string? commitLog, string? diff)
+    {
+        var sb = new StringBuilder();
+
+        sb.AppendLine("## What type of PR is this?");
+        sb.AppendLine();
+        sb.AppendLine(prType == "Feature" ? "- [x] Feature" : "- [ ] Feature");
+        sb.AppendLine(prType == "Bug Fix" ? "- [x] Bug Fix" : "- [ ] Bug Fix");
+        sb.AppendLine(prType == "Documentation Update" ? "- [x] Documentation Update" : "- [ ] Documentation Update");
+        sb.AppendLine(prType == "Code Refactor" ? "- [x] Code Refactor" : "- [ ] Code Refactor");
+        sb.AppendLine(prType == "Test" ? "- [x] Test" : "- [ ] Test");
+        sb.AppendLine("- [ ] Chore");
+        sb.AppendLine();
+
+        sb.AppendLine("## Description");
+        sb.AppendLine();
+        if (!string.IsNullOrEmpty(commitLog))
+        {
+            sb.AppendLine("### Changes");
+            foreach (var line in commitLog.Split('\n', StringSplitOptions.RemoveEmptyEntries).Take(10))
+            {
+                sb.AppendLine($"- {line.Trim()}");
+            }
+        }
+        else
+        {
+            sb.AppendLine("<!-- Describe your changes here -->");
+        }
+        sb.AppendLine();
+
+        sb.AppendLine("## Related Tickets & Documents");
+        sb.AppendLine();
+        sb.AppendLine($"Fixes #{issueNumber}");
+        sb.AppendLine();
+
+        sb.AppendLine("## Checklist");
+        sb.AppendLine();
+        sb.AppendLine("- [ ] Tested locally");
+        sb.AppendLine("- [ ] Updated documentation (if applicable)");
+        sb.AppendLine("- [ ] No breaking changes");
+        sb.AppendLine();
+
+        sb.AppendLine("---");
+        sb.AppendLine("*Created with [solve](https://github.com/MintPlayer/MintPlayer.Dotnet.Tools)*");
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Finds a PR template in the local repository.
+    /// </summary>
+    private static string? FindLocalPrTemplate()
+    {
+        foreach (var location in PrTemplateLocations)
+        {
+            if (File.Exists(location))
+            {
+                return location;
+            }
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Finds a PR template in the organization's .github repository.
+    /// </summary>
+    private async Task<(string? Content, string? Path)> FindOrgPrTemplateAsync(string owner, CancellationToken cancellationToken)
+    {
+        foreach (var location in OrgTemplateLocations)
+        {
+            var content = await _github.GetFileContentsAsync(owner, ".github", location, cancellationToken);
+            if (content != null)
+            {
+                return (content, location);
+            }
+        }
+        return (null, null);
+    }
+
+    /// <summary>
+    /// Processes a PR template by filling in placeholders.
+    /// </summary>
+    private static string ProcessPrTemplate(
+        string template,
+        int issueNumber,
+        string prType,
+        string? commitLog,
+        GitHubIssue? issue)
+    {
+
+        // Build changes summary from commit log
+        var changesSummary = new StringBuilder();
+        if (!string.IsNullOrEmpty(commitLog))
+        {
+            foreach (var line in commitLog.Split('\n', StringSplitOptions.RemoveEmptyEntries).Take(10))
+            {
+                changesSummary.AppendLine($"- {line.Trim()}");
+            }
+        }
+
+        // Replace common placeholders
+        var replacements = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            // Issue-related
+            ["{issue_number}"] = issueNumber.ToString(),
+            ["{issue-number}"] = issueNumber.ToString(),
+            ["{{issue_number}}"] = issueNumber.ToString(),
+            ["{{issue-number}}"] = issueNumber.ToString(),
+            ["{issueNumber}"] = issueNumber.ToString(),
+            ["#issue_number"] = $"#{issueNumber}",
+
+            // Issue title
+            ["{issue_title}"] = issue?.Title ?? "",
+            ["{issue-title}"] = issue?.Title ?? "",
+            ["{{issue_title}}"] = issue?.Title ?? "",
+            ["{issueTitle}"] = issue?.Title ?? "",
+
+            // PR type
+            ["{pr_type}"] = prType,
+            ["{pr-type}"] = prType,
+            ["{{pr_type}}"] = prType,
+            ["{prType}"] = prType,
+            ["{type}"] = prType,
+
+            // Changes/commits
+            ["{changes}"] = changesSummary.ToString().TrimEnd(),
+            ["{commits}"] = changesSummary.ToString().TrimEnd(),
+            ["{{changes}}"] = changesSummary.ToString().TrimEnd(),
+            ["{commit_log}"] = commitLog ?? "",
+            ["{commitLog}"] = commitLog ?? "",
+
+            // Labels
+            ["{labels}"] = issue != null ? string.Join(", ", issue.Labels) : "",
+            ["{{labels}}"] = issue != null ? string.Join(", ", issue.Labels) : "",
+
+            // Author
+            ["{author}"] = issue?.Author ?? "",
+            ["{{author}}"] = issue?.Author ?? "",
+        };
+
+        // Apply replacements
+        var result = template;
+        foreach (var (placeholder, value) in replacements)
+        {
+            result = result.Replace(placeholder, value, StringComparison.OrdinalIgnoreCase);
+        }
+
+        // Handle "Fixes #X" or "Closes #X" patterns - ensure issue number is filled in
+        result = Regex.Replace(
+            result,
+            @"(Fixes|Closes|Resolves|Related to)\s+#(\s*\n|$)",
+            $"$1 #{issueNumber}$2",
+            RegexOptions.IgnoreCase);
+
+        // Also handle empty brackets like "Fixes #[]" or "Fixes #[issue-number]"
+        result = Regex.Replace(
+            result,
+            @"(Fixes|Closes|Resolves|Related to)\s+#\[.*?\]",
+            $"$1 #{issueNumber}",
+            RegexOptions.IgnoreCase);
+
+        // Auto-check the appropriate PR type checkbox if present
+        result = AutoCheckPrType(result, prType);
+
+        return result;
+    }
+
+    /// <summary>
+    /// Auto-checks the appropriate PR type checkbox in the template.
+    /// </summary>
+    private static string AutoCheckPrType(string template, string prType)
+    {
+        var typePatterns = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Feature"] = ["feature", "feat", "enhancement"],
+            ["Bug Fix"] = ["bug", "bugfix", "bug fix", "fix"],
+            ["Documentation Update"] = ["documentation", "docs", "doc"],
+            ["Code Refactor"] = ["refactor", "refactoring", "code refactor"],
+            ["Test"] = ["test", "testing", "tests"],
+            ["Chore"] = ["chore", "maintenance", "release"]
+        };
+
+        foreach (var (type, patterns) in typePatterns)
+        {
+            if (type.Equals(prType, StringComparison.OrdinalIgnoreCase))
+            {
+                // Find and check the checkbox for this type
+                foreach (var pattern in patterns)
+                {
+                    // Match "- [ ] Feature" or "- [ ] 🍕 Feature" style checkboxes
+                    var regex = new Regex(
+                        @"^(\s*-\s*)\[\s*\](\s*[^\w]*\s*" + Regex.Escape(pattern) + @")",
+                        RegexOptions.IgnoreCase | RegexOptions.Multiline);
+
+                    if (regex.IsMatch(template))
+                    {
+                        template = regex.Replace(template, "$1[x]$2");
+                        return template; // Only check one
+                    }
+                }
+            }
+        }
+
+        return template;
+    }
+}

--- a/Solve/Commands/PrdCommand.cs
+++ b/Solve/Commands/PrdCommand.cs
@@ -1,0 +1,165 @@
+using MintPlayer.CliGenerator.Attributes;
+using MintPlayer.SourceGenerators.Attributes;
+using Solve.Models;
+using Solve.Services;
+
+namespace Solve.Commands;
+
+[CliCommand("prd", Description = "Generate PRD and development plan for an issue")]
+[CliParentCommand(typeof(SolveCommand))]
+public partial class PrdCommand : ICliCommand
+{
+    [Inject] private readonly IConsoleService _console;
+    [Inject] private readonly IGitService _git;
+    [Inject] private readonly IGitHubService _github;
+    [Inject] private readonly IPrdGenerator _prdGenerator;
+
+    [CliArgument(0, Name = "issue-url", Required = false, Description = "GitHub issue URL or reference (detects from branch if omitted)"), NoInterfaceMember]
+    public string? IssueUrl { get; set; }
+
+    [CliOption("--force", "-f", Description = "Overwrite existing PRD/plan"), NoInterfaceMember]
+    public bool Force { get; set; }
+
+    [CliOption("--update-issue", Description = "Update GitHub issue with clarifications"), NoInterfaceMember]
+    public bool UpdateIssue { get; set; }
+
+    public async Task<int> Execute(CancellationToken cancellationToken)
+    {
+        // Check prerequisites
+        if (!await _github.IsInstalledAsync(cancellationToken))
+        {
+            _console.WriteGhInstallInstructions();
+            return 1;
+        }
+
+        if (!await _github.IsAuthenticatedAsync(cancellationToken))
+        {
+            _console.WriteGhAuthInstructions();
+            return 1;
+        }
+
+        var (owner, repo) = await _git.GetRemoteInfoAsync(cancellationToken);
+        int? issueNumber = null;
+
+        // Try to get issue number from argument or branch
+        if (!string.IsNullOrEmpty(IssueUrl))
+        {
+            var issueRef = IssueReference.Parse(IssueUrl, owner, repo);
+            issueNumber = issueRef?.Number;
+        }
+        else
+        {
+            // Try to detect from branch name
+            var currentBranch = await _git.GetCurrentBranchAsync(cancellationToken);
+            if (!string.IsNullOrEmpty(currentBranch))
+            {
+                issueNumber = IssueReference.ExtractFromBranchName(currentBranch);
+                if (issueNumber.HasValue)
+                {
+                    _console.WriteInfo($"Detected issue #{issueNumber} from branch '{currentBranch}'");
+                }
+            }
+        }
+
+        if (!issueNumber.HasValue)
+        {
+            _console.WriteError("Error: Could not determine issue number.");
+            _console.WriteLine("Please provide an issue URL/reference or ensure you're on an issue branch.");
+            _console.WriteLine("Usage: solve prd <issue-url>");
+            _console.WriteLine("       solve prd  (when on issues/123-description branch)");
+            return 1;
+        }
+
+        // Check if PRD/plan already exist
+        if (!Force)
+        {
+            if (_prdGenerator.PrdExists(issueNumber.Value))
+            {
+                _console.WriteWarning($"PRD already exists: {_prdGenerator.GetPrdPath(issueNumber.Value)}");
+                if (!_console.Confirm("Overwrite?"))
+                    return 1;
+            }
+            if (_prdGenerator.PlanExists(issueNumber.Value))
+            {
+                _console.WriteWarning($"Plan already exists: {_prdGenerator.GetPlanPath(issueNumber.Value)}");
+                if (!_console.Confirm("Overwrite?"))
+                    return 1;
+            }
+        }
+
+        // Fetch issue details
+        _console.WriteInfo($"Fetching issue #{issueNumber}...");
+        var issue = owner != null && repo != null
+            ? await _github.GetIssueAsync(owner, repo, issueNumber.Value, cancellationToken)
+            : await _github.GetIssueAsync(issueNumber.Value, cancellationToken);
+
+        if (issue == null)
+        {
+            _console.WriteError($"Error: Could not fetch issue #{issueNumber}");
+            return 1;
+        }
+
+        _console.WriteLine($"  Title: {issue.Title}");
+        _console.WriteLine($"  Type: {issue.GetIssueType()}");
+        _console.WriteLine($"  Priority: {issue.GetPriority()}");
+
+        // Analyze issue clarity
+        var issueClear = AnalyzeIssueClarity(issue);
+        if (!issueClear)
+        {
+            _console.WriteWarning("\nThe issue description may be unclear or incomplete.");
+            _console.WriteLine("Consider adding:");
+            _console.WriteLine("  - Clear problem statement");
+            _console.WriteLine("  - Expected behavior");
+            _console.WriteLine("  - Acceptance criteria");
+
+            if (UpdateIssue && _console.Confirm("Would you like to update the issue description?"))
+            {
+                var clarification = _console.Prompt("Enter additional context to add");
+                if (!string.IsNullOrEmpty(clarification))
+                {
+                    var newBody = issue.Body + "\n\n---\n\n**Additional Context:**\n" + clarification;
+                    if (owner != null && repo != null)
+                    {
+                        await _github.UpdateIssueBodyAsync(owner, repo, issueNumber.Value, newBody, cancellationToken);
+                        _console.WriteSuccess("Issue updated.");
+                        issue.Body = newBody;
+                    }
+                }
+            }
+        }
+
+        // Generate development plan
+        _console.WriteInfo("\nGenerating development plan...");
+        var planContent = await _prdGenerator.GeneratePlanAsync(issue, cancellationToken);
+        var planPath = await _prdGenerator.SavePlanAsync(issueNumber.Value, planContent, force: true, cancellationToken);
+        _console.WriteSuccess($"Plan saved to: {planPath}");
+
+        // Generate PRD
+        _console.WriteInfo("Generating PRD...");
+        var prdContent = await _prdGenerator.GeneratePrdAsync(issue, cancellationToken);
+        var prdPath = await _prdGenerator.SavePrdAsync(issueNumber.Value, prdContent, force: true, cancellationToken);
+        _console.WriteSuccess($"PRD saved to: {prdPath}");
+
+        _console.WriteLine("\nNext steps:");
+        _console.WriteLine("  1. Review and refine the generated PRD and plan");
+        _console.WriteLine("  2. Run 'solve work' to start implementation with Claude Code");
+
+        return 0;
+    }
+
+    private static bool AnalyzeIssueClarity(GitHubIssue issue)
+    {
+        if (string.IsNullOrWhiteSpace(issue.Body))
+            return false;
+
+        var body = issue.Body.ToLowerInvariant();
+
+        // Check for common indicators of a well-defined issue
+        var hasDescription = issue.Body.Length > 50;
+        var hasExpectedBehavior = body.Contains("expect") || body.Contains("should") || body.Contains("want");
+        var hasAcceptanceCriteria = body.Contains("- [ ]") || body.Contains("acceptance") || body.Contains("criteria");
+
+        return hasDescription && (hasExpectedBehavior || hasAcceptanceCriteria);
+    }
+}

--- a/Solve/Commands/SolveCommand.cs
+++ b/Solve/Commands/SolveCommand.cs
@@ -1,0 +1,170 @@
+using MintPlayer.CliGenerator.Attributes;
+using MintPlayer.SourceGenerators.Attributes;
+using Solve.Models;
+using Solve.Services;
+
+namespace Solve.Commands;
+
+[CliRootCommand(Name = "solve", Description = "Delegate GitHub issues to Claude Code")]
+public partial class SolveCommand : ICliCommand
+{
+    [Inject] private readonly IConsoleService _console;
+    [Inject] private readonly IGitService _git;
+    [Inject] private readonly IGitHubService _github;
+    [Inject] private readonly IPrdGenerator _prdGenerator;
+    [Inject] private readonly IClaudeService _claude;
+
+    [CliArgument(0, Name = "issue-url", Required = false, Description = "GitHub issue URL or reference"), NoInterfaceMember]
+    public string? IssueUrl { get; set; }
+
+    [CliOption("--branch-prefix", "-p", Description = "Branch prefix", DefaultValue = "issues"), NoInterfaceMember]
+    public string BranchPrefix { get; set; } = "issues";
+
+    [CliOption("--skip-prd", Description = "Skip PRD generation"), NoInterfaceMember]
+    public bool SkipPrd { get; set; }
+
+    [CliOption("--skip-claude", Description = "Don't launch Claude Code after setup"), NoInterfaceMember]
+    public bool SkipClaude { get; set; }
+
+    [CliOption("--dry-run", Description = "Show what would be done without executing"), NoInterfaceMember]
+    public bool DryRun { get; set; }
+
+    public async Task<int> Execute(CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(IssueUrl))
+        {
+            _console.WriteError("Error: Issue URL or reference is required.");
+            _console.WriteLine("Usage: solve <issue-url>");
+            _console.WriteLine("       solve https://github.com/owner/repo/issues/123");
+            _console.WriteLine("       solve owner/repo#123");
+            _console.WriteLine("       solve #123");
+            return 1;
+        }
+
+        // Check prerequisites
+        if (!await _github.IsInstalledAsync(cancellationToken))
+        {
+            _console.WriteGhInstallInstructions();
+            return 1;
+        }
+
+        if (!await _github.IsAuthenticatedAsync(cancellationToken))
+        {
+            _console.WriteGhAuthInstructions();
+            return 1;
+        }
+
+        // Parse issue reference
+        var (owner, repo) = await _git.GetRemoteInfoAsync(cancellationToken);
+        var issueRef = IssueReference.Parse(IssueUrl, owner, repo);
+
+        if (issueRef == null)
+        {
+            _console.WriteError($"Error: Could not parse issue reference: {IssueUrl}");
+            return 1;
+        }
+
+        // Fetch issue details
+        _console.WriteInfo($"Fetching issue #{issueRef.Number}...");
+        var issue = issueRef.Owner != null && issueRef.Repo != null
+            ? await _github.GetIssueAsync(issueRef.Owner, issueRef.Repo, issueRef.Number, cancellationToken)
+            : await _github.GetIssueAsync(issueRef.Number, cancellationToken);
+
+        if (issue == null)
+        {
+            _console.WriteError($"Error: Could not fetch issue #{issueRef.Number}");
+            return 1;
+        }
+
+        _console.WriteLine($"  Title: {issue.Title}");
+        if (issue.Labels.Count > 0)
+            _console.WriteLine($"  Labels: {string.Join(", ", issue.Labels)}");
+
+        if (DryRun)
+        {
+            _console.WriteHeader("\n[DRY RUN] Would execute:");
+            _console.WriteLine($"  1. Switch to default branch and pull");
+            _console.WriteLine($"  2. Create branch: {BranchPrefix}/{issue.Number}-{issue.GetSlug()}");
+            if (!SkipPrd)
+            {
+                _console.WriteLine($"  3. Generate PRD at: {_prdGenerator.GetPrdPath(issue.Number)}");
+                _console.WriteLine($"  4. Generate plan at: {_prdGenerator.GetPlanPath(issue.Number)}");
+            }
+            if (!SkipClaude)
+                _console.WriteLine($"  5. Launch Claude Code");
+            return 0;
+        }
+
+        // Switch to default branch
+        var defaultBranch = await _git.GetDefaultBranchAsync(cancellationToken);
+        _console.WriteInfo($"Switching to default branch ({defaultBranch})...");
+        await _git.CheckoutAsync(defaultBranch!, cancellationToken);
+
+        // Pull latest
+        _console.WriteInfo("Pulling latest changes...");
+        await _git.PullAsync(cancellationToken);
+
+        // Create feature branch
+        var branchName = $"{BranchPrefix}/{issue.Number}-{issue.GetSlug()}";
+
+        // Check if branch already exists
+        if (await _git.BranchExistsAsync(branchName, cancellationToken))
+        {
+            _console.WriteWarning($"Branch '{branchName}' already exists.");
+            if (_console.Confirm("Switch to existing branch?"))
+            {
+                await _git.CheckoutAsync(branchName, cancellationToken);
+            }
+            else
+            {
+                return 1;
+            }
+        }
+        else
+        {
+            _console.WriteInfo($"Creating branch: {branchName}");
+            await _git.CreateBranchAsync(branchName, cancellationToken);
+        }
+
+        // Generate PRD and plan
+        if (!SkipPrd)
+        {
+            try
+            {
+                var planContent = await _prdGenerator.GeneratePlanAsync(issue, cancellationToken);
+                var planPath = await _prdGenerator.SavePlanAsync(issue.Number, planContent, force: false, cancellationToken);
+                _console.WriteSuccess($"Generated plan at: {planPath}");
+
+                var prdContent = await _prdGenerator.GeneratePrdAsync(issue, cancellationToken);
+                var prdPath = await _prdGenerator.SavePrdAsync(issue.Number, prdContent, force: false, cancellationToken);
+                _console.WriteSuccess($"Generated PRD at: {prdPath}");
+            }
+            catch (InvalidOperationException ex)
+            {
+                _console.WriteWarning(ex.Message);
+            }
+        }
+
+        // Launch Claude
+        if (!SkipClaude)
+        {
+            if (await _claude.IsAvailableAsync(cancellationToken))
+            {
+                _console.WriteInfo("Launching Claude Code...");
+                await _claude.LaunchForIssueAsync(
+                    issue,
+                    _prdGenerator.GetPlanPath(issue.Number),
+                    _prdGenerator.GetPrdPath(issue.Number),
+                    cancellationToken);
+            }
+            else
+            {
+                _console.WriteWarning("Claude CLI not found. Skipping Claude Code launch.");
+                _console.WriteLine("You can start Claude manually with the generated PRD and plan.");
+            }
+        }
+
+        _console.WriteSuccess("\nSetup complete!");
+        return 0;
+    }
+}

--- a/Solve/Commands/StatusCommand.cs
+++ b/Solve/Commands/StatusCommand.cs
@@ -1,0 +1,179 @@
+using System.Text.Json;
+using MintPlayer.CliGenerator.Attributes;
+using MintPlayer.SourceGenerators.Attributes;
+using Solve.Models;
+using Solve.Services;
+
+namespace Solve.Commands;
+
+[CliCommand("status", Description = "Show work status for an issue")]
+[CliParentCommand(typeof(SolveCommand))]
+public partial class StatusCommand : ICliCommand
+{
+    [Inject] private readonly IConsoleService _console;
+    [Inject] private readonly IGitService _git;
+    [Inject] private readonly IGitHubService _github;
+    [Inject] private readonly IPrdGenerator _prdGenerator;
+
+    [CliArgument(0, Name = "issue-url", Required = false, Description = "GitHub issue URL or reference (detects from branch if omitted)"), NoInterfaceMember]
+    public string? IssueUrl { get; set; }
+
+    [CliOption("--json", Description = "Output as JSON"), NoInterfaceMember]
+    public bool JsonOutput { get; set; }
+
+    public async Task<int> Execute(CancellationToken cancellationToken)
+    {
+        // Check prerequisites
+        if (!await _github.IsInstalledAsync(cancellationToken))
+        {
+            _console.WriteGhInstallInstructions();
+            return 1;
+        }
+
+        if (!await _github.IsAuthenticatedAsync(cancellationToken))
+        {
+            _console.WriteGhAuthInstructions();
+            return 1;
+        }
+
+        var (owner, repo) = await _git.GetRemoteInfoAsync(cancellationToken);
+        var currentBranch = await _git.GetCurrentBranchAsync(cancellationToken);
+        int? issueNumber = null;
+
+        // Try to get issue number from argument or branch
+        if (!string.IsNullOrEmpty(IssueUrl))
+        {
+            var issueRef = IssueReference.Parse(IssueUrl, owner, repo);
+            issueNumber = issueRef?.Number;
+        }
+        else if (!string.IsNullOrEmpty(currentBranch))
+        {
+            issueNumber = IssueReference.ExtractFromBranchName(currentBranch);
+        }
+
+        if (!issueNumber.HasValue)
+        {
+            if (JsonOutput)
+            {
+                Console.WriteLine(JsonSerializer.Serialize(new { error = "Could not determine issue number" }));
+            }
+            else
+            {
+                _console.WriteError("Error: Could not determine issue number.");
+                _console.WriteLine("Please provide an issue URL/reference or ensure you're on an issue branch.");
+            }
+            return 1;
+        }
+
+        // Fetch issue details
+        var issue = owner != null && repo != null
+            ? await _github.GetIssueAsync(owner, repo, issueNumber.Value, cancellationToken)
+            : await _github.GetIssueAsync(issueNumber.Value, cancellationToken);
+
+        var issueTitle = issue?.Title ?? $"Issue #{issueNumber}";
+
+        // Parse status from PRD
+        var status = await _prdGenerator.ParseWorkStatusAsync(issueNumber.Value, issueTitle, cancellationToken);
+
+        if (status == null)
+        {
+            status = new WorkStatus
+            {
+                IssueNumber = issueNumber.Value,
+                IssueTitle = issueTitle,
+                PrdStatus = "Not Created",
+                ImplementationStatus = "Not Started"
+            };
+        }
+
+        // Check for uncommitted changes
+        status.HasUncommittedChanges = await _git.HasUncommittedChangesAsync(cancellationToken);
+
+        // Check for open PR
+        var pr = await _github.GetPullRequestForBranchAsync(cancellationToken);
+        if (pr.HasValue)
+        {
+            status.OpenPrUrl = pr.Value.Url;
+        }
+
+        if (JsonOutput)
+        {
+            var options = new JsonSerializerOptions { WriteIndented = true };
+            Console.WriteLine(JsonSerializer.Serialize(status, options));
+        }
+        else
+        {
+            DisplayStatus(status);
+        }
+
+        return 0;
+    }
+
+    private void DisplayStatus(WorkStatus status)
+    {
+        _console.WriteHeader($"\n## Issue #{status.IssueNumber}: {status.IssueTitle}");
+        _console.WriteLine();
+        _console.WriteLine($"**PRD Status**: {status.PrdStatus}");
+        _console.WriteLine($"**Implementation Status**: {status.ImplementationStatus}");
+
+        if (status.TotalRequirements > 0)
+        {
+            _console.WriteLine();
+            _console.WriteLine("### Progress Summary");
+            _console.WriteLine($"- Requirements: {status.CompletedRequirements}/{status.TotalRequirements} ({status.CompletionPercentage}%)");
+
+            // Progress bar
+            var filled = status.CompletionPercentage / 5;
+            var empty = 20 - filled;
+            _console.WriteLine($"  [{"".PadRight(filled, '#')}{"".PadRight(empty, '-')}]");
+        }
+
+        if (status.CompletedItems.Count > 0)
+        {
+            _console.WriteLine();
+            _console.WriteSuccess($"### Completed ({status.CompletedItems.Count})");
+            foreach (var item in status.CompletedItems.Take(5))
+            {
+                _console.WriteLine($"  - {item}");
+            }
+            if (status.CompletedItems.Count > 5)
+                _console.WriteLine($"  ... and {status.CompletedItems.Count - 5} more");
+        }
+
+        if (status.RemainingItems.Count > 0)
+        {
+            _console.WriteLine();
+            _console.WriteLine($"### Remaining ({status.RemainingItems.Count})");
+            foreach (var item in status.RemainingItems.Take(5))
+            {
+                _console.WriteLine($"  - {item}");
+            }
+            if (status.RemainingItems.Count > 5)
+                _console.WriteLine($"  ... and {status.RemainingItems.Count - 5} more");
+        }
+
+        if (status.OpenQuestions.Count > 0)
+        {
+            _console.WriteLine();
+            _console.WriteWarning($"### Open Questions ({status.OpenQuestions.Count})");
+            foreach (var q in status.OpenQuestions)
+            {
+                _console.WriteLine($"  - {q}");
+            }
+        }
+
+        if (status.HasUncommittedChanges)
+        {
+            _console.WriteLine();
+            _console.WriteWarning("Note: Uncommitted changes detected");
+        }
+
+        if (!string.IsNullOrEmpty(status.OpenPrUrl))
+        {
+            _console.WriteLine();
+            _console.WriteInfo($"Open PR: {status.OpenPrUrl}");
+        }
+
+        _console.WriteLine();
+    }
+}

--- a/Solve/Commands/WorkCommand.cs
+++ b/Solve/Commands/WorkCommand.cs
@@ -1,0 +1,200 @@
+using MintPlayer.CliGenerator.Attributes;
+using MintPlayer.SourceGenerators.Attributes;
+using Solve.Models;
+using Solve.Services;
+
+namespace Solve.Commands;
+
+[CliCommand("work", Description = "Start or continue working on an issue")]
+[CliParentCommand(typeof(SolveCommand))]
+public partial class WorkCommand : ICliCommand
+{
+    [Inject] private readonly IConsoleService _console;
+    [Inject] private readonly IGitService _git;
+    [Inject] private readonly IGitHubService _github;
+    [Inject] private readonly IPrdGenerator _prdGenerator;
+    [Inject] private readonly IClaudeService _claude;
+
+    [CliArgument(0, Name = "issue-url", Required = false, Description = "GitHub issue URL or reference (detects from branch if omitted)"), NoInterfaceMember]
+    public string? IssueUrl { get; set; }
+
+    [CliOption("--status-only", Description = "Only show status, don't launch Claude"), NoInterfaceMember]
+    public bool StatusOnly { get; set; }
+
+    public async Task<int> Execute(CancellationToken cancellationToken)
+    {
+        // Check prerequisites
+        if (!await _github.IsInstalledAsync(cancellationToken))
+        {
+            _console.WriteGhInstallInstructions();
+            return 1;
+        }
+
+        if (!await _github.IsAuthenticatedAsync(cancellationToken))
+        {
+            _console.WriteGhAuthInstructions();
+            return 1;
+        }
+
+        var (owner, repo) = await _git.GetRemoteInfoAsync(cancellationToken);
+        var currentBranch = await _git.GetCurrentBranchAsync(cancellationToken);
+        int? issueNumber = null;
+
+        // Try to get issue number from argument or branch
+        if (!string.IsNullOrEmpty(IssueUrl))
+        {
+            var issueRef = IssueReference.Parse(IssueUrl, owner, repo);
+            issueNumber = issueRef?.Number;
+        }
+        else if (!string.IsNullOrEmpty(currentBranch))
+        {
+            issueNumber = IssueReference.ExtractFromBranchName(currentBranch);
+            if (issueNumber.HasValue)
+            {
+                _console.WriteInfo($"Detected issue #{issueNumber} from branch '{currentBranch}'");
+            }
+        }
+
+        if (!issueNumber.HasValue)
+        {
+            _console.WriteError("Error: Could not determine issue number.");
+            _console.WriteLine("Please provide an issue URL/reference or ensure you're on an issue branch.");
+            _console.WriteLine("Usage: solve work <issue-url>");
+            _console.WriteLine("       solve work  (when on issues/123-description branch)");
+            return 1;
+        }
+
+        // Check for required files
+        var hasPrd = _prdGenerator.PrdExists(issueNumber.Value);
+        var hasPlan = _prdGenerator.PlanExists(issueNumber.Value);
+
+        if (!hasPrd || !hasPlan)
+        {
+            _console.WriteError($"The development plan and/or PRD for Issue #{issueNumber} could not be found.");
+            _console.WriteLine();
+            _console.WriteLine("Missing files:");
+            if (!hasPlan)
+                _console.WriteLine($"  - {_prdGenerator.GetPlanPath(issueNumber.Value)}");
+            if (!hasPrd)
+                _console.WriteLine($"  - {_prdGenerator.GetPrdPath(issueNumber.Value)}");
+            _console.WriteLine();
+            _console.WriteLine("Please run 'solve prd' first to create the development plan and PRD.");
+            return 1;
+        }
+
+        // Fetch issue details
+        var issue = owner != null && repo != null
+            ? await _github.GetIssueAsync(owner, repo, issueNumber.Value, cancellationToken)
+            : await _github.GetIssueAsync(issueNumber.Value, cancellationToken);
+
+        var issueTitle = issue?.Title ?? $"Issue #{issueNumber}";
+
+        // Parse and display status
+        var status = await _prdGenerator.ParseWorkStatusAsync(issueNumber.Value, issueTitle, cancellationToken);
+
+        if (status != null)
+        {
+            DisplayStatus(status);
+        }
+
+        // Check for uncommitted changes
+        if (await _git.HasUncommittedChangesAsync(cancellationToken))
+        {
+            _console.WriteWarning("\nNote: You have uncommitted changes.");
+        }
+
+        // Check for open PR
+        var pr = await _github.GetPullRequestForBranchAsync(cancellationToken);
+        if (pr.HasValue)
+        {
+            _console.WriteInfo($"\nOpen PR: #{pr.Value.Number} - {pr.Value.Title}");
+            _console.WriteLine($"  {pr.Value.Url}");
+        }
+
+        if (StatusOnly)
+        {
+            return 0;
+        }
+
+        // Launch Claude
+        _console.WriteLine();
+        if (await _claude.IsAvailableAsync(cancellationToken))
+        {
+            _console.WriteInfo("Launching Claude Code...");
+            if (issue != null)
+            {
+                await _claude.LaunchForIssueAsync(
+                    issue,
+                    _prdGenerator.GetPlanPath(issueNumber.Value),
+                    _prdGenerator.GetPrdPath(issueNumber.Value),
+                    cancellationToken);
+            }
+        }
+        else
+        {
+            _console.WriteWarning("Claude CLI not found.");
+            _console.WriteLine("You can start Claude manually with:");
+            _console.WriteLine($"  PRD: {_prdGenerator.GetPrdPath(issueNumber.Value)}");
+            _console.WriteLine($"  Plan: {_prdGenerator.GetPlanPath(issueNumber.Value)}");
+        }
+
+        return 0;
+    }
+
+    private void DisplayStatus(WorkStatus status)
+    {
+        _console.WriteHeader($"\n## Issue #{status.IssueNumber}: {status.IssueTitle}");
+        _console.WriteLine();
+        _console.WriteLine($"**PRD Status**: {status.PrdStatus}");
+        _console.WriteLine($"**Implementation Status**: {status.ImplementationStatus}");
+        _console.WriteLine();
+
+        _console.WriteLine("### Progress Summary");
+        _console.WriteLine($"- Functional Requirements: {status.CompletedRequirements} of {status.TotalRequirements} completed");
+        _console.WriteLine();
+
+        if (status.CompletedItems.Count > 0)
+        {
+            _console.WriteSuccess("### Completed");
+            foreach (var item in status.CompletedItems.Take(10))
+            {
+                _console.WriteLine($"- [x] {item}");
+            }
+            if (status.CompletedItems.Count > 10)
+                _console.WriteLine($"  ... and {status.CompletedItems.Count - 10} more");
+            _console.WriteLine();
+        }
+
+        if (status.RemainingItems.Count > 0)
+        {
+            _console.WriteLine("### Remaining Work");
+            foreach (var item in status.RemainingItems.Take(10))
+            {
+                _console.WriteLine($"- [ ] {item}");
+            }
+            if (status.RemainingItems.Count > 10)
+                _console.WriteLine($"  ... and {status.RemainingItems.Count - 10} more");
+            _console.WriteLine();
+        }
+
+        if (status.OpenQuestions.Count > 0)
+        {
+            _console.WriteWarning("### Open Questions");
+            foreach (var question in status.OpenQuestions)
+            {
+                _console.WriteLine($"- {question}");
+            }
+            _console.WriteLine();
+        }
+
+        if (status.Blockers.Count > 0)
+        {
+            _console.WriteError("### Blockers");
+            foreach (var blocker in status.Blockers)
+            {
+                _console.WriteLine($"- {blocker}");
+            }
+            _console.WriteLine();
+        }
+    }
+}

--- a/Solve/Models/GitHubIssue.cs
+++ b/Solve/Models/GitHubIssue.cs
@@ -1,0 +1,75 @@
+namespace Solve.Models;
+
+/// <summary>
+/// Represents a GitHub issue with its details.
+/// </summary>
+public class GitHubIssue
+{
+    public int Number { get; set; }
+    public string Title { get; set; } = string.Empty;
+    public string Body { get; set; } = string.Empty;
+    public string State { get; set; } = string.Empty;
+    public string Author { get; set; } = string.Empty;
+    public List<string> Labels { get; set; } = [];
+    public string Url { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets the issue type based on labels.
+    /// </summary>
+    public string GetIssueType()
+    {
+        var labelSet = new HashSet<string>(Labels.Select(l => l.ToLowerInvariant()));
+
+        if (labelSet.Contains("bug") || labelSet.Contains("bugfix"))
+            return "Bug Fix";
+        if (labelSet.Contains("enhancement") || labelSet.Contains("feature"))
+            return "Feature";
+        if (labelSet.Contains("documentation") || labelSet.Contains("docs"))
+            return "Documentation";
+        if (labelSet.Contains("refactor") || labelSet.Contains("refactoring"))
+            return "Refactor";
+        if (labelSet.Contains("test") || labelSet.Contains("testing"))
+            return "Test";
+
+        return "Feature"; // Default
+    }
+
+    /// <summary>
+    /// Gets the priority based on labels.
+    /// </summary>
+    public string GetPriority()
+    {
+        var labelSet = new HashSet<string>(Labels.Select(l => l.ToLowerInvariant()));
+
+        if (labelSet.Any(l => l.Contains("critical") || l.Contains("urgent") || l.Contains("p0")))
+            return "High";
+        if (labelSet.Any(l => l.Contains("high") || l.Contains("p1")))
+            return "High";
+        if (labelSet.Any(l => l.Contains("low") || l.Contains("p3")))
+            return "Low";
+
+        return "Medium"; // Default
+    }
+
+    /// <summary>
+    /// Generates a URL-safe slug from the title.
+    /// </summary>
+    public string GetSlug(int maxLength = 30)
+    {
+        if (string.IsNullOrEmpty(Title))
+            return "issue";
+
+        // Convert to lowercase and replace spaces/special chars with hyphens
+        var slug = Title.ToLowerInvariant();
+        slug = System.Text.RegularExpressions.Regex.Replace(slug, @"[^a-z0-9]+", "-");
+        slug = slug.Trim('-');
+
+        // Truncate if necessary
+        if (slug.Length > maxLength)
+        {
+            slug = slug[..maxLength].TrimEnd('-');
+        }
+
+        return string.IsNullOrEmpty(slug) ? "issue" : slug;
+    }
+}

--- a/Solve/Models/IssueReference.cs
+++ b/Solve/Models/IssueReference.cs
@@ -1,0 +1,111 @@
+using System.Text.RegularExpressions;
+
+namespace Solve.Models;
+
+/// <summary>
+/// Represents a parsed GitHub issue reference.
+/// </summary>
+public partial class IssueReference
+{
+    public string? Owner { get; set; }
+    public string? Repo { get; set; }
+    public int Number { get; set; }
+
+    /// <summary>
+    /// Parses an issue reference from various formats.
+    /// </summary>
+    /// <param name="input">The input string (URL, short ref, or number)</param>
+    /// <param name="currentRepoOwner">Owner from current git repo context</param>
+    /// <param name="currentRepoName">Repo name from current git repo context</param>
+    /// <returns>Parsed issue reference or null if parsing fails</returns>
+    public static IssueReference? Parse(string? input, string? currentRepoOwner = null, string? currentRepoName = null)
+    {
+        if (string.IsNullOrWhiteSpace(input))
+            return null;
+
+        input = input.Trim();
+
+        // Full URL: https://github.com/owner/repo/issues/123
+        var urlMatch = GitHubUrlRegex().Match(input);
+        if (urlMatch.Success)
+        {
+            return new IssueReference
+            {
+                Owner = urlMatch.Groups["owner"].Value,
+                Repo = urlMatch.Groups["repo"].Value,
+                Number = int.Parse(urlMatch.Groups["number"].Value)
+            };
+        }
+
+        // Short reference: owner/repo#123
+        var shortMatch = ShortRefRegex().Match(input);
+        if (shortMatch.Success)
+        {
+            return new IssueReference
+            {
+                Owner = shortMatch.Groups["owner"].Value,
+                Repo = shortMatch.Groups["repo"].Value,
+                Number = int.Parse(shortMatch.Groups["number"].Value)
+            };
+        }
+
+        // Number only: #123 or 123
+        var numberMatch = NumberOnlyRegex().Match(input);
+        if (numberMatch.Success)
+        {
+            return new IssueReference
+            {
+                Owner = currentRepoOwner,
+                Repo = currentRepoName,
+                Number = int.Parse(numberMatch.Groups["number"].Value)
+            };
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Extracts issue number from a branch name.
+    /// Supports: issues/123, issues/#123, issues/123-description, feature/issue-123-description
+    /// </summary>
+    public static int? ExtractFromBranchName(string branchName)
+    {
+        // Pattern: issues/123 or issues/#123 or issues/123-description
+        var issuesBranchMatch = IssuesBranchRegex().Match(branchName);
+        if (issuesBranchMatch.Success)
+        {
+            return int.Parse(issuesBranchMatch.Groups["number"].Value);
+        }
+
+        // Pattern: feature/issue-123-description or similar
+        var featureBranchMatch = FeatureIssueBranchRegex().Match(branchName);
+        if (featureBranchMatch.Success)
+        {
+            return int.Parse(featureBranchMatch.Groups["number"].Value);
+        }
+
+        return null;
+    }
+
+    public override string ToString()
+    {
+        if (!string.IsNullOrEmpty(Owner) && !string.IsNullOrEmpty(Repo))
+            return $"{Owner}/{Repo}#{Number}";
+        return $"#{Number}";
+    }
+
+    [GeneratedRegex(@"^https?://github\.com/(?<owner>[^/]+)/(?<repo>[^/]+)/issues/(?<number>\d+)")]
+    private static partial Regex GitHubUrlRegex();
+
+    [GeneratedRegex(@"^(?<owner>[^/]+)/(?<repo>[^#]+)#(?<number>\d+)$")]
+    private static partial Regex ShortRefRegex();
+
+    [GeneratedRegex(@"^#?(?<number>\d+)$")]
+    private static partial Regex NumberOnlyRegex();
+
+    [GeneratedRegex(@"^issues/[#]?(?<number>\d+)")]
+    private static partial Regex IssuesBranchRegex();
+
+    [GeneratedRegex(@"issue[s]?[-/](?<number>\d+)", RegexOptions.IgnoreCase)]
+    private static partial Regex FeatureIssueBranchRegex();
+}

--- a/Solve/Models/WorkStatus.cs
+++ b/Solve/Models/WorkStatus.cs
@@ -1,0 +1,26 @@
+namespace Solve.Models;
+
+/// <summary>
+/// Represents the current work status for an issue.
+/// </summary>
+public class WorkStatus
+{
+    public int IssueNumber { get; set; }
+    public string IssueTitle { get; set; } = string.Empty;
+    public string PrdStatus { get; set; } = "Not Started";
+    public string ImplementationStatus { get; set; } = "Not Started";
+
+    public int TotalRequirements { get; set; }
+    public int CompletedRequirements { get; set; }
+
+    public List<string> CompletedItems { get; set; } = [];
+    public List<string> RemainingItems { get; set; } = [];
+    public List<string> OpenQuestions { get; set; } = [];
+    public List<string> Blockers { get; set; } = [];
+
+    public bool HasUncommittedChanges { get; set; }
+    public string? OpenPrUrl { get; set; }
+
+    public int CompletionPercentage =>
+        TotalRequirements > 0 ? (CompletedRequirements * 100) / TotalRequirements : 0;
+}

--- a/Solve/PRD.md
+++ b/Solve/PRD.md
@@ -1,0 +1,850 @@
+# Product Requirements Document: Solve CLI Tool
+
+**Project**: Solve CLI Tool
+**Status**: Draft
+**Author**: Claude
+**Created**: 2026-01-27
+**Last Updated**: 2026-01-27
+
+---
+
+## Overview
+
+**Solve** is a CLI tool that streamlines the workflow of delegating GitHub issues to Claude Code. It automates the repetitive setup steps (branch management, PRD creation) and provides a structured interface for issue-driven development.
+
+The tool wraps common git operations and Claude Code interactions into simple commands, essentially providing a CLI interface to the workflow defined in the DeCronosGroep claude commands (`create_for_issue`, `work_on`, `create_pull_request`, `resolve_pr_feedback`).
+
+---
+
+## Goals & Objectives
+
+### Primary Goals
+- Reduce manual steps when starting work on a GitHub issue
+- Provide a consistent, repeatable workflow for issue-driven development
+- Launch Claude Code with full context (issue details, PRD, development plan)
+- Work seamlessly with any GitHub repository
+
+### Success Metrics
+- Single command to go from issue URL to ready-to-develop state
+- Eliminates need to manually run 4+ git commands before starting work
+- Consistent PRD structure across all issues
+- Seamless handoff to Claude Code for implementation
+
+---
+
+## User Stories
+
+### As a Developer
+I want to run a single command with a GitHub issue URL
+So that I can immediately start working on the issue without manual branch setup
+
+### As a Team Lead
+I want consistent PRDs generated for each issue
+So that implementation plans are documented and reviewable
+
+### As a Developer
+I want to resume work on an issue I started earlier
+So that I can pick up where I left off with full context
+
+### As a Developer
+I want to create a PR when my work is done
+So that I can submit my changes for review with proper documentation
+
+---
+
+## Command Structure
+
+```
+solve <issue-url>              # Full workflow: init + prd + work
+solve init <issue-url>         # Setup: switch branch, pull, create feature branch
+solve prd [issue-url]          # Generate PRD and development plan
+solve work [issue-url]         # Resume work on issue (loads PRD, shows status)
+solve pr [issue-url]           # Create pull request
+solve feedback [pr-url]        # Review and resolve PR feedback
+solve status [issue-url]       # Show current status of issue work
+```
+
+---
+
+## Detailed Command Specifications
+
+### Root Command: `solve <issue-url>`
+
+The default command runs the full workflow:
+
+1. **Parse issue reference** - Extract owner, repo, and issue number
+2. **Fetch issue details** - Get title, body, labels from GitHub API via `gh`
+3. **Switch to default branch** - Detect and checkout main/master/development
+4. **Pull latest changes** - `git pull`
+5. **Create feature branch** - `issues/<number>-<slug>`
+6. **Generate PRD** - Create `docs/issue_<number>_PRD.md`
+7. **Generate development plan** - Create `.claude/plans/issue_<number>.md`
+8. **Launch Claude Code** - Start implementation with full context
+
+**Arguments:**
+- `issue-url` (required): GitHub issue URL or reference
+
+**Options:**
+- `--branch-prefix` / `-p`: Custom branch prefix (default: `issues`)
+- `--skip-prd`: Skip PRD generation
+- `--skip-claude`: Don't launch Claude Code after setup
+- `--dry-run`: Show what would be done without executing
+
+---
+
+### Subcommand: `solve init <issue-url>`
+
+Setup-only mode (mirrors first part of `create_for_issue`):
+
+1. Parse issue reference
+2. Check if branch already exists for this issue
+3. If exists: offer to switch to it
+4. If not: switch to default branch, pull, create feature branch
+5. Display next steps
+
+**Arguments:**
+- `issue-url` (required): GitHub issue URL or reference
+
+**Options:**
+- `--branch-prefix` / `-p`: Custom branch prefix (default: `issues`)
+- `--no-pull`: Skip git pull
+- `--force`: Create new branch even if one exists
+
+**Output:**
+```
+Fetching issue #42...
+  Title: Add user authentication
+  Labels: enhancement, security
+Switching to default branch (development)...
+Pulling latest changes...
+Creating branch: issues/42-add-user-authentication
+Done! Run 'solve prd' to generate the PRD.
+```
+
+---
+
+### Subcommand: `solve prd [issue-url]`
+
+Generate PRD and development plan (mirrors `create_for_issue` steps 2-6):
+
+1. Detect issue number from current branch if not provided
+2. Fetch issue details via `gh issue view`
+3. Analyze issue clarity (problem statement, outcomes, requirements)
+4. If unclear: prompt user for clarification
+5. Optionally update issue description on GitHub
+6. Generate development plan at `.claude/plans/issue_<number>.md`
+7. Generate PRD at `docs/issue_<number>_PRD.md`
+
+**Arguments:**
+- `issue-url` (optional): GitHub issue URL or reference. If omitted, detect from branch name.
+
+**Options:**
+- `--output` / `-o`: Custom output directory
+- `--force` / `-f`: Overwrite existing PRD/plan
+- `--update-issue`: Update GitHub issue with clarifications
+
+**Branch Detection:**
+Extracts issue number from patterns like:
+- `issues/123`
+- `issues/#123`
+- `issues/123-description`
+- `feature/issue-123-description`
+
+---
+
+### Subcommand: `solve work [issue-url]`
+
+Start/continue implementation (mirrors `work_on`):
+
+1. Detect issue number from branch or argument
+2. If not on correct branch: offer to switch
+3. Check for PRD and development plan files
+4. If missing: prompt to run `solve prd` first
+5. Read and analyze PRD/plan files
+6. Show status summary (completed items, remaining work, blockers)
+7. Launch Claude Code with context
+
+**Arguments:**
+- `issue-url` (optional): GitHub issue URL or reference. If omitted, detect from branch.
+
+**Options:**
+- `--status-only`: Only show status, don't launch Claude
+- `--continue` / `-c`: Continue from last session
+
+**Status Output:**
+```
+## Issue #42: Add user authentication
+
+**PRD Status**: In Progress
+**Implementation Status**: 40% complete
+
+### Progress Summary
+- Functional Requirements: 2 of 5 completed
+- Milestones: M1 complete, M2 in progress
+
+### Completed
+- [x] FR-1: User model created
+- [x] FR-2: Login endpoint implemented
+
+### Remaining Work
+- [ ] FR-3: JWT token generation
+- [ ] FR-4: Password reset flow
+- [ ] FR-5: Session management
+
+### Open Questions
+- None
+
+What would you like to work on?
+```
+
+---
+
+### Subcommand: `solve pr [issue-url]`
+
+Create pull request (mirrors `create_pull_request`):
+
+1. Detect issue from branch or argument
+2. Run pre-PR checklist (configurable)
+3. Analyze commits and diff against base branch
+4. Draft PR description using template
+5. Show preview to user
+6. On confirmation: push branch, create PR via `gh pr create`
+
+**Arguments:**
+- `issue-url` (optional): Detect from branch if omitted
+
+**Options:**
+- `--draft` / `-d`: Create as draft PR
+- `--base` / `-b`: Target branch (default: auto-detect development/main)
+- `--title` / `-t`: Custom PR title (default: issue title)
+- `--no-checklist`: Skip pre-PR checklist
+- `--yes` / `-y`: Skip confirmation
+
+**PR Template:**
+```markdown
+## What type of PR is this?
+
+- [ ] 🍕 Feature
+- [ ] 🐛 Bug Fix
+- [ ] 📝 Documentation Update
+- [ ] 🧑‍💻 Code Refactor
+- [ ] ✅ Test
+- [ ] 📦 Chore
+
+## Description
+
+[Auto-generated from commits and diff analysis]
+
+## Related Tickets & Documents
+
+Fixes #<issue-number>
+
+## Checklist
+
+- [ ] Tested locally
+- [ ] Updated documentation
+- [ ] No breaking changes
+```
+
+---
+
+### Subcommand: `solve feedback [pr-url]`
+
+Review and resolve PR feedback (mirrors `resolve_pr_feedback`):
+
+1. Detect PR from current branch or argument
+2. Fetch unresolved review threads via GitHub GraphQL API
+3. Analyze each comment/change request
+4. Assess validity (valid, partially valid, not valid)
+5. Present summary with assessments
+6. Create development plan for valid feedback
+7. On confirmation: implement changes, update PRD if needed
+8. Reply to reviewers and resolve threads
+
+**Arguments:**
+- `pr-url` (optional): PR URL or number. Detect from branch if omitted.
+
+**Options:**
+- `--assess-only`: Only show assessment, don't implement
+- `--auto-reply`: Automatically reply to resolved items
+
+---
+
+### Subcommand: `solve status [issue-url]`
+
+Show work status without launching Claude:
+
+1. Detect issue from branch or argument
+2. Read PRD and development plan
+3. Analyze completion status
+4. Check for uncommitted changes
+5. Check for open PR
+
+**Arguments:**
+- `issue-url` (optional): Detect from branch if omitted
+
+**Options:**
+- `--json`: Output as JSON for scripting
+
+---
+
+## Functional Requirements
+
+### Must Have (P0)
+
+- [ ] **FR-1**: Parse GitHub issue references in multiple formats:
+  - Full URL: `https://github.com/owner/repo/issues/123`
+  - Short reference: `owner/repo#123`
+  - Number only: `#123` or `123` (within git repo context)
+
+- [ ] **FR-2**: Detect issue number from branch name patterns:
+  - `issues/123`, `issues/#123`, `issues/123-description`
+  - `feature/issue-123-description`
+
+- [ ] **FR-3**: Detect default branch automatically (main, master, development, or repo default via `gh`)
+
+- [ ] **FR-4**: Create consistently named feature branches (`issues/<number>-<slug>`)
+
+- [ ] **FR-5**: Generate structured development plan at `.claude/plans/issue_<number>.md`
+
+- [ ] **FR-6**: Generate structured PRD at `docs/issue_<number>_PRD.md`
+
+- [ ] **FR-7**: Invoke Claude Code CLI with appropriate context
+
+- [ ] **FR-8**: Support all subcommands (init, prd, work, pr, feedback, status)
+
+### Should Have (P1)
+
+- [ ] **FR-9**: Pre-PR checklist with configurable items
+
+- [ ] **FR-10**: PR template customization via config file
+
+- [ ] **FR-11**: Analyze PR feedback validity
+
+- [ ] **FR-12**: Reply to PR comments via GitHub API
+
+- [ ] **FR-13**: Update PRD/plan based on PR feedback
+
+### Could Have (P2)
+
+- [ ] **FR-14**: Configuration file for defaults (branch prefix, templates, checklist)
+
+- [ ] **FR-15**: Support for multiple GitHub remotes
+
+- [ ] **FR-16**: Interactive mode for issue clarification
+
+---
+
+## Non-Functional Requirements
+
+### Performance
+- **NFR-1**: Commands should complete within 5 seconds (excluding network operations)
+
+### Compatibility
+- **NFR-2**: Work on Windows, macOS, and Linux
+- **NFR-3**: Require only `git` and `gh` CLI as external dependencies
+- **NFR-4**: Optional: `claude` CLI for launching Claude Code
+
+### Usability
+- **NFR-5**: Provide clear error messages with suggested fixes
+- **NFR-6**: Support `--help` for all commands
+- **NFR-7**: Colorized output for better readability
+
+### Security
+- **NFR-8**: Never store GitHub credentials (rely on `gh` authentication)
+- **NFR-9**: Validate URLs before making requests
+
+---
+
+## Technical Specifications
+
+### Architecture
+
+```
+Solve/
+├── Solve.csproj                    # Console app project
+├── Program.cs                      # Entry point
+├── Commands/
+│   ├── SolveCommand.cs             # Root command [CliRootCommand]
+│   ├── InitCommand.cs              # [CliCommand] init
+│   ├── PrdCommand.cs               # [CliCommand] prd
+│   ├── WorkCommand.cs              # [CliCommand] work
+│   ├── PrCommand.cs                # [CliCommand] pr
+│   ├── FeedbackCommand.cs          # [CliCommand] feedback
+│   └── StatusCommand.cs            # [CliCommand] status
+├── Services/
+│   ├── IGitHubService.cs           # GitHub API interactions via gh CLI
+│   ├── GitHubService.cs
+│   ├── IGitService.cs              # Git operations
+│   ├── GitService.cs
+│   ├── IIssueParser.cs             # Issue URL/reference parsing
+│   ├── IssueParser.cs
+│   ├── IBranchService.cs           # Branch detection and management
+│   ├── BranchService.cs
+│   ├── IPrdGenerator.cs            # PRD document generation
+│   ├── PrdGenerator.cs
+│   ├── IClaudeService.cs           # Claude Code CLI integration
+│   └── ClaudeService.cs
+├── Models/
+│   ├── GitHubIssue.cs              # Issue model
+│   ├── IssueReference.cs           # Parsed issue reference
+│   ├── PullRequest.cs              # PR model
+│   ├── ReviewThread.cs             # PR review thread
+│   └── WorkStatus.cs               # Work status model
+└── Templates/
+    ├── PrdTemplate.md              # Embedded PRD template
+    ├── PlanTemplate.md             # Embedded development plan template
+    └── PrTemplate.md               # Embedded PR template
+```
+
+### Command Implementation Pattern
+
+Using MintPlayer.CliGenerator with nested commands:
+
+```csharp
+[CliRootCommand(Name = "solve", Description = "Delegate GitHub issues to Claude Code")]
+public partial class SolveCommand : ICliCommand
+{
+    private readonly IIssueParser _issueParser;
+    private readonly IGitService _gitService;
+    private readonly IGitHubService _githubService;
+    private readonly IPrdGenerator _prdGenerator;
+    private readonly IClaudeService _claudeService;
+
+    public SolveCommand(
+        IIssueParser issueParser,
+        IGitService gitService,
+        IGitHubService githubService,
+        IPrdGenerator prdGenerator,
+        IClaudeService claudeService)
+    {
+        _issueParser = issueParser;
+        _gitService = gitService;
+        _githubService = githubService;
+        _prdGenerator = prdGenerator;
+        _claudeService = claudeService;
+    }
+
+    [CliArgument(0, Name = "issue-url", Required = false)]
+    public string? IssueUrl { get; set; }
+
+    [CliOption("--branch-prefix", "-p")]
+    public string BranchPrefix { get; set; } = "issues";
+
+    [CliOption("--skip-prd")]
+    public bool SkipPrd { get; set; }
+
+    [CliOption("--skip-claude")]
+    public bool SkipClaude { get; set; }
+
+    [CliOption("--dry-run")]
+    public bool DryRun { get; set; }
+
+    public async Task<int> Execute(CancellationToken cancellationToken)
+    {
+        // Full workflow: init + prd + work
+        // 1. Parse issue reference
+        // 2. Init branch
+        // 3. Generate PRD
+        // 4. Launch Claude
+    }
+
+    [CliCommand("init", Description = "Initialize branch for issue")]
+    public partial class InitCommand : ICliCommand
+    {
+        [CliArgument(0, Name = "issue-url")]
+        public string IssueUrl { get; set; } = string.Empty;
+
+        [CliOption("--branch-prefix", "-p")]
+        public string BranchPrefix { get; set; } = "issues";
+
+        [CliOption("--no-pull")]
+        public bool NoPull { get; set; }
+
+        [CliOption("--force")]
+        public bool Force { get; set; }
+
+        public Task<int> Execute(CancellationToken cancellationToken) { ... }
+    }
+
+    [CliCommand("prd", Description = "Generate PRD and development plan")]
+    public partial class PrdCommand : ICliCommand
+    {
+        [CliArgument(0, Name = "issue-url", Required = false)]
+        public string? IssueUrl { get; set; }
+
+        [CliOption("--output", "-o")]
+        public string? OutputDirectory { get; set; }
+
+        [CliOption("--force", "-f")]
+        public bool Force { get; set; }
+
+        [CliOption("--update-issue")]
+        public bool UpdateIssue { get; set; }
+
+        public Task<int> Execute(CancellationToken cancellationToken) { ... }
+    }
+
+    [CliCommand("work", Description = "Start/continue working on issue")]
+    public partial class WorkCommand : ICliCommand
+    {
+        [CliArgument(0, Name = "issue-url", Required = false)]
+        public string? IssueUrl { get; set; }
+
+        [CliOption("--status-only")]
+        public bool StatusOnly { get; set; }
+
+        [CliOption("--continue", "-c")]
+        public bool Continue { get; set; }
+
+        public Task<int> Execute(CancellationToken cancellationToken) { ... }
+    }
+
+    [CliCommand("pr", Description = "Create pull request")]
+    public partial class PrCommand : ICliCommand
+    {
+        [CliArgument(0, Name = "issue-url", Required = false)]
+        public string? IssueUrl { get; set; }
+
+        [CliOption("--draft", "-d")]
+        public bool Draft { get; set; }
+
+        [CliOption("--base", "-b")]
+        public string? BaseBranch { get; set; }
+
+        [CliOption("--title", "-t")]
+        public string? Title { get; set; }
+
+        [CliOption("--no-checklist")]
+        public bool NoChecklist { get; set; }
+
+        [CliOption("--yes", "-y")]
+        public bool SkipConfirmation { get; set; }
+
+        public Task<int> Execute(CancellationToken cancellationToken) { ... }
+    }
+
+    [CliCommand("feedback", Description = "Review and resolve PR feedback")]
+    public partial class FeedbackCommand : ICliCommand
+    {
+        [CliArgument(0, Name = "pr-url", Required = false)]
+        public string? PrUrl { get; set; }
+
+        [CliOption("--assess-only")]
+        public bool AssessOnly { get; set; }
+
+        [CliOption("--auto-reply")]
+        public bool AutoReply { get; set; }
+
+        public Task<int> Execute(CancellationToken cancellationToken) { ... }
+    }
+
+    [CliCommand("status", Description = "Show work status")]
+    public partial class StatusCommand : ICliCommand
+    {
+        [CliArgument(0, Name = "issue-url", Required = false)]
+        public string? IssueUrl { get; set; }
+
+        [CliOption("--json")]
+        public bool JsonOutput { get; set; }
+
+        public Task<int> Execute(CancellationToken cancellationToken) { ... }
+    }
+}
+```
+
+### External Dependencies
+
+| Dependency | Purpose | Required |
+|------------|---------|----------|
+| `gh` CLI | GitHub API access (authentication, issues, PRs) | Yes |
+| `git` CLI | Branch management, pull, push operations | Yes |
+| `claude` CLI | Claude Code invocation | Optional |
+
+### Issue Reference Parsing
+
+```csharp
+public class IssueReference
+{
+    public string? Owner { get; set; }
+    public string? Repo { get; set; }
+    public int Number { get; set; }
+
+    public static IssueReference? Parse(string input, string? currentRepoOwner = null, string? currentRepoName = null)
+    {
+        // Full URL: https://github.com/owner/repo/issues/123
+        // Short: owner/repo#123
+        // Number only: #123 or 123
+    }
+}
+```
+
+### Branch Naming
+
+Format: `{prefix}/{number}-{slug}`
+
+- `prefix`: Configurable (default: `issues`)
+- `number`: Issue number
+- `slug`: Sanitized issue title (lowercase, hyphens, max 30 chars)
+
+Example: `issues/42-add-user-authentication`
+
+### Claude Code Integration
+
+```bash
+# Launch Claude with context
+claude --print "You are working on GitHub issue #<number>.
+
+Issue: <title>
+<issue body>
+
+PRD: docs/issue_<number>_PRD.md
+Development Plan: .claude/plans/issue_<number>.md
+
+Please analyze the requirements and begin implementation following the development plan."
+```
+
+---
+
+## Document Templates
+
+### Development Plan Template (`.claude/plans/issue_<number>.md`)
+
+```markdown
+# Development Plan: Issue #<number>
+
+**Issue**: #<number>
+**Title**: <issue title>
+**Type**: <Feature/Bug Fix/Refactor/etc.>
+**Priority**: <High/Medium/Low>
+
+## Executive Summary
+
+<Brief description of what needs to be done and why>
+
+---
+
+## Problem Statement
+
+### Current Behavior
+<What currently happens>
+
+### Expected Behavior
+<What should happen after implementation>
+
+### Impact
+<Business/user impact>
+
+---
+
+## Technical Analysis
+
+### Files to Modify
+<List of files that need changes>
+
+### Dependencies
+<External services, packages, or other issues this depends on>
+
+### Architecture Considerations
+<Any architectural decisions or patterns to follow>
+
+---
+
+## Implementation Plan
+
+### Phase 1: <Name>
+1. <Step 1>
+2. <Step 2>
+
+### Phase 2: <Name> (if applicable)
+...
+
+---
+
+## Test Scenarios
+
+### Scenario 1: <Name>
+- **Given**: <preconditions>
+- **When**: <action>
+- **Then**: <expected result>
+
+---
+
+## Acceptance Criteria
+
+- [ ] <Criterion 1>
+- [ ] <Criterion 2>
+
+---
+
+## Related Files
+
+- <file1>
+- <file2>
+```
+
+### PRD Template (`docs/issue_<number>_PRD.md`)
+
+```markdown
+# Product Requirements Document: <Feature Name>
+
+**Issue**: #<number>
+**Title**: <issue title>
+**Status**: Draft
+**Created**: <date>
+**Last Updated**: <date>
+
+---
+
+## Overview
+
+<High-level description of the feature/fix - keep brief>
+
+---
+
+## Goals & Objectives
+
+### Primary Goals
+- <Goal 1>
+- <Goal 2>
+
+### Success Metrics
+- <Metric 1>
+- <Metric 2>
+
+---
+
+## Functional Requirements
+
+### Must Have (P0)
+- [ ] **FR-1**: <requirement>
+- [ ] **FR-2**: <requirement>
+
+### Should Have (P1)
+- [ ] **FR-3**: <requirement>
+
+---
+
+## Timeline & Milestones
+
+### Milestone 1: <Name>
+- [ ] Task 1
+- [ ] Task 2
+
+### Milestone 2: <Name>
+- [ ] Task 3
+
+---
+
+## Open Questions
+
+- [ ] <Question 1>
+- [ ] <Question 2>
+
+---
+
+## Technical Notes (Issue-Specific)
+
+<Only include notes specific to THIS issue>
+
+---
+
+## Related
+- Issue #<number>
+```
+
+---
+
+## Risks & Mitigations
+
+| Risk | Impact | Probability | Mitigation |
+|------|--------|-------------|------------|
+| `gh` CLI not installed | High | Medium | Check for dependency at startup, provide installation instructions |
+| No GitHub authentication | High | Medium | Prompt user to run `gh auth login` |
+| Branch already exists | Medium | Medium | Offer to switch to existing branch or create new |
+| PRD already exists | Low | Medium | Ask to overwrite or skip (--force flag) |
+| Network failures | Medium | Low | Retry logic, clear error messages |
+| Claude CLI not installed | Low | Medium | Graceful degradation, show manual instructions |
+
+---
+
+## Implementation Milestones
+
+### Milestone 1: Core Infrastructure
+- [ ] Project setup with CliGenerator
+- [ ] Issue URL/reference parsing
+- [ ] Git service (branch detection, default branch, branch creation)
+- [ ] GitHub service (issue fetching via `gh`)
+
+### Milestone 2: Init and PRD Commands
+- [ ] `solve init` command
+- [ ] `solve prd` command
+- [ ] PRD and plan templates
+- [ ] Branch detection from name
+
+### Milestone 3: Work and Status Commands
+- [ ] `solve work` command
+- [ ] `solve status` command
+- [ ] Status analysis from PRD/plan files
+
+### Milestone 4: Full Workflow
+- [ ] Root `solve` command (full workflow)
+- [ ] Claude Code integration
+
+### Milestone 5: PR and Feedback Commands
+- [ ] `solve pr` command
+- [ ] `solve feedback` command
+- [ ] PR template
+- [ ] GitHub GraphQL for review threads
+
+---
+
+## Open Questions
+
+- [x] Should PRDs be stored in `.claude/plans/` or `docs/`? → **PRD in `docs/`, plan in `.claude/plans/`**
+- [x] Branch naming convention? → **`issues/<number>-<slug>`**
+- [ ] Should we support a config file for defaults (`.solverc` or similar)?
+- [ ] How to handle repositories without write access (fork workflow)?
+- [ ] Should `solve feedback` auto-commit changes or leave for user?
+
+---
+
+## Appendix
+
+### Example Usage Session
+
+```bash
+# Full workflow - from issue URL to implementation
+$ solve https://github.com/myorg/myrepo/issues/42
+Fetching issue #42...
+  Title: Add user authentication
+  Labels: enhancement, security
+Switching to default branch (development)...
+Pulling latest changes...
+Creating branch: issues/42-add-user-authentication
+Generating PRD at docs/issue_42_PRD.md...
+Generating plan at .claude/plans/issue_42.md...
+Launching Claude Code...
+
+# Or step by step:
+$ solve init https://github.com/myorg/myrepo/issues/42
+$ solve prd
+$ solve work
+
+# When done:
+$ solve pr
+Creating PR for issue #42...
+PR created: https://github.com/myorg/myrepo/pull/43
+
+# After review feedback:
+$ solve feedback
+Fetching unresolved review threads...
+Found 3 items to address...
+```
+
+### References
+
+- [DeCronosGroep Claude Commands](https://github.com/DeCronosGroep/claude/tree/development/plugins/dcg/commands)
+- [MintPlayer.CliGenerator](./SourceGenerators/Cli)
+- [GitHub CLI (`gh`) Documentation](https://cli.github.com/)
+- [Claude Code Documentation](https://docs.anthropic.com/en/docs/claude-code)

--- a/Solve/Program.cs
+++ b/Solve/Program.cs
@@ -1,0 +1,34 @@
+using Microsoft.Extensions.Hosting;
+using MintPlayer.CliGenerator.Attributes;
+using Solve;
+
+var builder = Host.CreateApplicationBuilder(args);
+builder.Services
+    .AddSolveCommand()
+    .AddSolveServices();
+
+var app = builder.Build();
+
+try
+{
+    var exitCode = await app.InvokeSolveCommandAsync(args);
+    return exitCode;
+}
+catch (ParseCommandException parseEx)
+{
+    Console.ForegroundColor = ConsoleColor.Red;
+    Console.Error.WriteLine("Error parsing command:");
+    foreach (var error in parseEx.Errors)
+    {
+        Console.Error.WriteLine($"  {error}");
+    }
+    Console.ResetColor();
+    return 1;
+}
+catch (Exception ex)
+{
+    Console.ForegroundColor = ConsoleColor.Red;
+    Console.Error.WriteLine($"Error: {ex.Message}");
+    Console.ResetColor();
+    return 1;
+}

--- a/Solve/Services/ClaudeService.cs
+++ b/Solve/Services/ClaudeService.cs
@@ -1,0 +1,117 @@
+using System.Diagnostics;
+using System.Text;
+using Microsoft.Extensions.DependencyInjection;
+using MintPlayer.SourceGenerators.Attributes;
+using Solve.Models;
+
+namespace Solve.Services;
+
+[Register(typeof(IClaudeService), ServiceLifetime.Scoped, "SolveServices")]
+public class ClaudeService : IClaudeService
+{
+    public async Task<bool> IsAvailableAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            using var process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = "claude",
+                    Arguments = "--version",
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                }
+            };
+
+            process.Start();
+            await process.WaitForExitAsync(cancellationToken);
+            return process.ExitCode == 0;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    public async Task<bool> LaunchForIssueAsync(GitHubIssue issue, string? planPath, string? prdPath, CancellationToken cancellationToken = default)
+    {
+        var prompt = new StringBuilder();
+        prompt.AppendLine($"You are working on GitHub issue #{issue.Number}.");
+        prompt.AppendLine();
+        prompt.AppendLine($"## Issue: {issue.Title}");
+        prompt.AppendLine();
+
+        if (!string.IsNullOrWhiteSpace(issue.Body))
+        {
+            prompt.AppendLine("### Description");
+            prompt.AppendLine(issue.Body);
+            prompt.AppendLine();
+        }
+
+        if (issue.Labels.Count > 0)
+        {
+            prompt.AppendLine($"### Labels: {string.Join(", ", issue.Labels)}");
+            prompt.AppendLine();
+        }
+
+        if (!string.IsNullOrEmpty(prdPath) && File.Exists(prdPath))
+        {
+            prompt.AppendLine($"### PRD: {prdPath}");
+        }
+
+        if (!string.IsNullOrEmpty(planPath) && File.Exists(planPath))
+        {
+            prompt.AppendLine($"### Development Plan: {planPath}");
+        }
+
+        prompt.AppendLine();
+        prompt.AppendLine("Please read the PRD and development plan, then analyze the requirements and begin implementation.");
+
+        return await LaunchWithPromptAsync(prompt.ToString(), cancellationToken);
+    }
+
+    public async Task<bool> LaunchWithPromptAsync(string prompt, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            // Write prompt to temp file to avoid shell escaping issues
+            var tempFile = Path.GetTempFileName();
+            try
+            {
+                await File.WriteAllTextAsync(tempFile, prompt, cancellationToken);
+
+                using var process = new Process
+                {
+                    StartInfo = new ProcessStartInfo
+                    {
+                        FileName = "claude",
+                        Arguments = $"--print < \"{tempFile}\"",
+                        UseShellExecute = true,
+                        CreateNoWindow = false
+                    }
+                };
+
+                process.Start();
+
+                // Don't wait for Claude to exit - it runs interactively
+                return true;
+            }
+            finally
+            {
+                // Clean up temp file after a delay (Claude should have read it by then)
+                _ = Task.Delay(5000, cancellationToken).ContinueWith(_ =>
+                {
+                    if (File.Exists(tempFile))
+                        File.Delete(tempFile);
+                }, TaskScheduler.Default);
+            }
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/Solve/Services/ConsoleService.cs
+++ b/Solve/Services/ConsoleService.cs
@@ -1,0 +1,99 @@
+using Microsoft.Extensions.DependencyInjection;
+using MintPlayer.SourceGenerators.Attributes;
+
+namespace Solve.Services;
+
+[Register(typeof(IConsoleService), ServiceLifetime.Singleton, "SolveServices")]
+public class ConsoleService : IConsoleService
+{
+    public void WriteLine(string message = "")
+    {
+        Console.WriteLine(message);
+    }
+
+    public void WriteInfo(string message)
+    {
+        Console.ForegroundColor = ConsoleColor.Cyan;
+        Console.WriteLine(message);
+        Console.ResetColor();
+    }
+
+    public void WriteSuccess(string message)
+    {
+        Console.ForegroundColor = ConsoleColor.Green;
+        Console.WriteLine(message);
+        Console.ResetColor();
+    }
+
+    public void WriteWarning(string message)
+    {
+        Console.ForegroundColor = ConsoleColor.Yellow;
+        Console.WriteLine(message);
+        Console.ResetColor();
+    }
+
+    public void WriteError(string message)
+    {
+        Console.ForegroundColor = ConsoleColor.Red;
+        Console.WriteLine(message);
+        Console.ResetColor();
+    }
+
+    public void WriteHeader(string message)
+    {
+        Console.ForegroundColor = ConsoleColor.Magenta;
+        Console.WriteLine(message);
+        Console.ResetColor();
+    }
+
+    public bool Confirm(string message)
+    {
+        Console.Write($"{message} (y/n): ");
+        var response = Console.ReadLine()?.Trim().ToLowerInvariant();
+        return response == "y" || response == "yes";
+    }
+
+    public string? Prompt(string message)
+    {
+        Console.Write($"{message}: ");
+        return Console.ReadLine()?.Trim();
+    }
+
+    public void WriteGhInstallInstructions()
+    {
+        WriteError("Error: GitHub CLI (gh) is not installed.");
+        WriteLine();
+        WriteLine("The solve tool requires the GitHub CLI to interact with GitHub.");
+        WriteLine();
+        WriteHeader("Installation instructions:");
+        WriteLine();
+        WriteLine("  Windows (winget):  winget install GitHub.cli");
+        WriteLine("  Windows (scoop):   scoop install gh");
+        WriteLine("  Windows (choco):   choco install gh");
+        WriteLine("  macOS (Homebrew):  brew install gh");
+        WriteLine("  Linux (apt):       sudo apt install gh");
+        WriteLine("  Linux (dnf):       sudo dnf install gh");
+        WriteLine();
+        WriteLine("For other installation methods, visit:");
+        WriteInfo("  https://cli.github.com/manual/installation");
+        WriteLine();
+        WriteLine("After installation, authenticate with:");
+        WriteInfo("  gh auth login");
+    }
+
+    public void WriteGhAuthInstructions()
+    {
+        WriteError("Error: GitHub CLI (gh) is not authenticated.");
+        WriteLine();
+        WriteLine("Please authenticate with GitHub by running:");
+        WriteInfo("  gh auth login");
+        WriteLine();
+        WriteLine("Follow the prompts to complete authentication.");
+        WriteLine("You can choose to authenticate via:");
+        WriteLine("  - Browser (recommended)");
+        WriteLine("  - Personal access token");
+        WriteLine();
+        WriteLine("For more information, visit:");
+        WriteInfo("  https://cli.github.com/manual/gh_auth_login");
+    }
+}

--- a/Solve/Services/GitHubService.cs
+++ b/Solve/Services/GitHubService.cs
@@ -1,0 +1,279 @@
+using System.Diagnostics;
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using MintPlayer.SourceGenerators.Attributes;
+using Solve.Models;
+
+namespace Solve.Services;
+
+[Register(typeof(IGitHubService), ServiceLifetime.Scoped, "SolveServices")]
+public class GitHubService : IGitHubService
+{
+    public async Task<bool> IsInstalledAsync(CancellationToken cancellationToken = default)
+    {
+        var result = await RunGhAsync("--version", cancellationToken);
+        return result.Success;
+    }
+
+    public async Task<bool> IsAuthenticatedAsync(CancellationToken cancellationToken = default)
+    {
+        var result = await RunGhAsync("auth status", cancellationToken);
+        return result.Success;
+    }
+
+    public async Task<GitHubIssue?> GetIssueAsync(string owner, string repo, int number, CancellationToken cancellationToken = default)
+    {
+        var result = await RunGhAsync(
+            $"issue view {number} --repo {owner}/{repo} --json number,title,body,state,author,labels,url",
+            cancellationToken);
+
+        if (!result.Success || string.IsNullOrEmpty(result.Output))
+            return null;
+
+        try
+        {
+            using var doc = JsonDocument.Parse(result.Output);
+            var root = doc.RootElement;
+
+            var issue = new GitHubIssue
+            {
+                Number = root.GetProperty("number").GetInt32(),
+                Title = root.GetProperty("title").GetString() ?? string.Empty,
+                Body = root.GetProperty("body").GetString() ?? string.Empty,
+                State = root.GetProperty("state").GetString() ?? string.Empty,
+                Url = root.GetProperty("url").GetString() ?? string.Empty
+            };
+
+            if (root.TryGetProperty("author", out var author) && author.TryGetProperty("login", out var login))
+            {
+                issue.Author = login.GetString() ?? string.Empty;
+            }
+
+            if (root.TryGetProperty("labels", out var labels))
+            {
+                foreach (var label in labels.EnumerateArray())
+                {
+                    if (label.TryGetProperty("name", out var name))
+                    {
+                        issue.Labels.Add(name.GetString() ?? string.Empty);
+                    }
+                }
+            }
+
+            return issue;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    public async Task<GitHubIssue?> GetIssueAsync(int number, CancellationToken cancellationToken = default)
+    {
+        var result = await RunGhAsync(
+            $"issue view {number} --json number,title,body,state,author,labels,url",
+            cancellationToken);
+
+        if (!result.Success || string.IsNullOrEmpty(result.Output))
+            return null;
+
+        try
+        {
+            using var doc = JsonDocument.Parse(result.Output);
+            var root = doc.RootElement;
+
+            var issue = new GitHubIssue
+            {
+                Number = root.GetProperty("number").GetInt32(),
+                Title = root.GetProperty("title").GetString() ?? string.Empty,
+                Body = root.GetProperty("body").GetString() ?? string.Empty,
+                State = root.GetProperty("state").GetString() ?? string.Empty,
+                Url = root.GetProperty("url").GetString() ?? string.Empty
+            };
+
+            if (root.TryGetProperty("author", out var author) && author.TryGetProperty("login", out var login))
+            {
+                issue.Author = login.GetString() ?? string.Empty;
+            }
+
+            if (root.TryGetProperty("labels", out var labels))
+            {
+                foreach (var label in labels.EnumerateArray())
+                {
+                    if (label.TryGetProperty("name", out var name))
+                    {
+                        issue.Labels.Add(name.GetString() ?? string.Empty);
+                    }
+                }
+            }
+
+            return issue;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    public async Task<bool> UpdateIssueBodyAsync(string owner, string repo, int number, string body, CancellationToken cancellationToken = default)
+    {
+        // Write body to temp file to avoid escaping issues
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(tempFile, body, cancellationToken);
+            var result = await RunGhAsync(
+                $"issue edit {number} --repo {owner}/{repo} --body-file \"{tempFile}\"",
+                cancellationToken);
+            return result.Success;
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+
+    public async Task<(int Number, string Title, string Url)?> GetPullRequestForBranchAsync(CancellationToken cancellationToken = default)
+    {
+        var result = await RunGhAsync("pr view --json number,title,url", cancellationToken);
+
+        if (!result.Success || string.IsNullOrEmpty(result.Output))
+            return null;
+
+        try
+        {
+            using var doc = JsonDocument.Parse(result.Output);
+            var root = doc.RootElement;
+
+            return (
+                root.GetProperty("number").GetInt32(),
+                root.GetProperty("title").GetString() ?? string.Empty,
+                root.GetProperty("url").GetString() ?? string.Empty
+            );
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    public async Task<string?> CreatePullRequestAsync(string title, string body, string baseBranch, bool draft = false, CancellationToken cancellationToken = default)
+    {
+        // Write body to temp file to avoid escaping issues
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(tempFile, body, cancellationToken);
+
+            var draftFlag = draft ? "--draft" : "";
+            var result = await RunGhAsync(
+                $"pr create --title \"{EscapeQuotes(title)}\" --body-file \"{tempFile}\" --base {baseBranch} {draftFlag}",
+                cancellationToken);
+
+            return result.Success ? result.Output?.Trim() : null;
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+
+    public async Task<string?> GetPullRequestReviewsAsync(string owner, string repo, int prNumber, CancellationToken cancellationToken = default)
+    {
+        // Use GraphQL to get unresolved review threads
+        var query = """
+            query($owner: String!, $repo: String!, $pr: Int!) {
+              repository(owner: $owner, name: $repo) {
+                pullRequest(number: $pr) {
+                  reviews(first: 50, states: [CHANGES_REQUESTED, COMMENTED]) {
+                    nodes {
+                      author { login }
+                      state
+                      body
+                    }
+                  }
+                  reviewThreads(first: 100) {
+                    nodes {
+                      isResolved
+                      path
+                      line
+                      comments(first: 50) {
+                        nodes {
+                          author { login }
+                          body
+                          createdAt
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            """;
+
+        var result = await RunGhAsync(
+            $"api graphql -f query='{EscapeForShell(query)}' -f owner={owner} -f repo={repo} -F pr={prNumber}",
+            cancellationToken);
+
+        return result.Success ? result.Output : null;
+    }
+
+    public async Task<string?> GetFileContentsAsync(string owner, string repo, string path, CancellationToken cancellationToken = default)
+    {
+        // Use gh api to get file contents
+        var result = await RunGhAsync(
+            $"api repos/{owner}/{repo}/contents/{path} --jq .content",
+            cancellationToken);
+
+        if (!result.Success || string.IsNullOrEmpty(result.Output))
+            return null;
+
+        try
+        {
+            // GitHub returns base64 encoded content
+            var base64Content = result.Output.Trim().Replace("\n", "");
+            var bytes = Convert.FromBase64String(base64Content);
+            return System.Text.Encoding.UTF8.GetString(bytes);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static async Task<(bool Success, string? Output)> RunGhAsync(string arguments, CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = "gh",
+                    Arguments = arguments,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                }
+            };
+
+            process.Start();
+            var output = await process.StandardOutput.ReadToEndAsync(cancellationToken);
+            await process.WaitForExitAsync(cancellationToken);
+
+            return (process.ExitCode == 0, output);
+        }
+        catch
+        {
+            return (false, null);
+        }
+    }
+
+    private static string EscapeQuotes(string input) => input.Replace("\"", "\\\"");
+
+    private static string EscapeForShell(string input) =>
+        input.Replace("'", "'\\''").Replace("\r\n", " ").Replace("\n", " ");
+}

--- a/Solve/Services/GitService.cs
+++ b/Solve/Services/GitService.cs
@@ -1,0 +1,194 @@
+using System.Diagnostics;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.DependencyInjection;
+using MintPlayer.SourceGenerators.Attributes;
+
+namespace Solve.Services;
+
+[Register(typeof(IGitService), ServiceLifetime.Scoped, "SolveServices")]
+public partial class GitService : IGitService
+{
+    public async Task<string?> GetCurrentBranchAsync(CancellationToken cancellationToken = default)
+    {
+        var result = await RunGitAsync("rev-parse --abbrev-ref HEAD", cancellationToken);
+        return result.Success ? result.Output?.Trim() : null;
+    }
+
+    public async Task<string?> GetDefaultBranchAsync(CancellationToken cancellationToken = default)
+    {
+        // Try to get from remote HEAD
+        var result = await RunGitAsync("symbolic-ref refs/remotes/origin/HEAD --short", cancellationToken);
+        if (result.Success && !string.IsNullOrEmpty(result.Output))
+        {
+            // Returns something like "origin/main" - extract just the branch name
+            var branch = result.Output.Trim();
+            if (branch.StartsWith("origin/"))
+                return branch["origin/".Length..];
+            return branch;
+        }
+
+        // Fallback: check common default branch names
+        var commonDefaults = new[] { "main", "master", "development", "develop" };
+        foreach (var defaultBranch in commonDefaults)
+        {
+            if (await BranchExistsAsync(defaultBranch, cancellationToken))
+                return defaultBranch;
+        }
+
+        return "main"; // Ultimate fallback
+    }
+
+    public async Task<bool> BranchExistsAsync(string branchName, CancellationToken cancellationToken = default)
+    {
+        // Check local
+        var localResult = await RunGitAsync($"show-ref --verify --quiet refs/heads/{branchName}", cancellationToken);
+        if (localResult.Success)
+            return true;
+
+        // Check remote
+        var remoteResult = await RunGitAsync($"ls-remote --heads origin {branchName}", cancellationToken);
+        return remoteResult.Success && !string.IsNullOrWhiteSpace(remoteResult.Output);
+    }
+
+    public async Task<List<string>> FindBranchesAsync(string pattern, CancellationToken cancellationToken = default)
+    {
+        var branches = new List<string>();
+
+        // Search all branches (local and remote)
+        var result = await RunGitAsync("branch -a", cancellationToken);
+        if (!result.Success || string.IsNullOrEmpty(result.Output))
+            return branches;
+
+        var regex = new Regex(pattern, RegexOptions.IgnoreCase);
+        foreach (var line in result.Output.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var branch = line.Trim().TrimStart('*').Trim();
+            if (branch.StartsWith("remotes/origin/"))
+                branch = branch["remotes/origin/".Length..];
+
+            if (regex.IsMatch(branch) && !branches.Contains(branch))
+                branches.Add(branch);
+        }
+
+        return branches;
+    }
+
+    public async Task<bool> CheckoutAsync(string branchName, CancellationToken cancellationToken = default)
+    {
+        var result = await RunGitAsync($"checkout {branchName}", cancellationToken);
+        return result.Success;
+    }
+
+    public async Task<bool> CreateBranchAsync(string branchName, CancellationToken cancellationToken = default)
+    {
+        var result = await RunGitAsync($"checkout -b {branchName}", cancellationToken);
+        return result.Success;
+    }
+
+    public async Task<bool> FetchAsync(CancellationToken cancellationToken = default)
+    {
+        var result = await RunGitAsync("fetch origin", cancellationToken);
+        return result.Success;
+    }
+
+    public async Task<bool> PullAsync(CancellationToken cancellationToken = default)
+    {
+        var result = await RunGitAsync("pull", cancellationToken);
+        return result.Success;
+    }
+
+    public async Task<bool> PushAsync(bool setUpstream = false, CancellationToken cancellationToken = default)
+    {
+        var args = setUpstream ? "push -u origin HEAD" : "push";
+        var result = await RunGitAsync(args, cancellationToken);
+        return result.Success;
+    }
+
+    public async Task<(string? Owner, string? Repo)> GetRemoteInfoAsync(CancellationToken cancellationToken = default)
+    {
+        var result = await RunGitAsync("remote get-url origin", cancellationToken);
+        if (!result.Success || string.IsNullOrEmpty(result.Output))
+            return (null, null);
+
+        var url = result.Output.Trim();
+
+        // Parse SSH format: git@github.com:owner/repo.git
+        var sshMatch = SshRemoteRegex().Match(url);
+        if (sshMatch.Success)
+        {
+            return (sshMatch.Groups["owner"].Value, sshMatch.Groups["repo"].Value.TrimSuffix(".git"));
+        }
+
+        // Parse HTTPS format: https://github.com/owner/repo.git
+        var httpsMatch = HttpsRemoteRegex().Match(url);
+        if (httpsMatch.Success)
+        {
+            return (httpsMatch.Groups["owner"].Value, httpsMatch.Groups["repo"].Value.TrimSuffix(".git"));
+        }
+
+        return (null, null);
+    }
+
+    public async Task<bool> HasUncommittedChangesAsync(CancellationToken cancellationToken = default)
+    {
+        var result = await RunGitAsync("status --porcelain", cancellationToken);
+        return result.Success && !string.IsNullOrWhiteSpace(result.Output);
+    }
+
+    public async Task<string?> GetLogAsync(string baseRef, string headRef = "HEAD", CancellationToken cancellationToken = default)
+    {
+        var result = await RunGitAsync($"log {baseRef}..{headRef} --oneline", cancellationToken);
+        return result.Success ? result.Output : null;
+    }
+
+    public async Task<string?> GetDiffAsync(string baseRef, string headRef = "HEAD", CancellationToken cancellationToken = default)
+    {
+        var result = await RunGitAsync($"diff {baseRef}...{headRef}", cancellationToken);
+        return result.Success ? result.Output : null;
+    }
+
+    private static async Task<(bool Success, string? Output)> RunGitAsync(string arguments, CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = "git",
+                    Arguments = arguments,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                }
+            };
+
+            process.Start();
+            var output = await process.StandardOutput.ReadToEndAsync(cancellationToken);
+            await process.WaitForExitAsync(cancellationToken);
+
+            return (process.ExitCode == 0, output);
+        }
+        catch
+        {
+            return (false, null);
+        }
+    }
+
+    [GeneratedRegex(@"git@github\.com:(?<owner>[^/]+)/(?<repo>.+)")]
+    private static partial Regex SshRemoteRegex();
+
+    [GeneratedRegex(@"https://github\.com/(?<owner>[^/]+)/(?<repo>.+)")]
+    private static partial Regex HttpsRemoteRegex();
+}
+
+internal static class StringExtensions
+{
+    public static string TrimSuffix(this string str, string suffix)
+    {
+        return str.EndsWith(suffix, StringComparison.OrdinalIgnoreCase)
+            ? str[..^suffix.Length]
+            : str;
+    }
+}

--- a/Solve/Services/IClaudeService.cs
+++ b/Solve/Services/IClaudeService.cs
@@ -1,0 +1,24 @@
+using Solve.Models;
+
+namespace Solve.Services;
+
+/// <summary>
+/// Service for interacting with Claude Code CLI.
+/// </summary>
+public interface IClaudeService
+{
+    /// <summary>
+    /// Checks if the Claude CLI is available.
+    /// </summary>
+    Task<bool> IsAvailableAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Launches Claude Code with context for working on an issue.
+    /// </summary>
+    Task<bool> LaunchForIssueAsync(GitHubIssue issue, string? planPath, string? prdPath, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Launches Claude Code with a custom prompt.
+    /// </summary>
+    Task<bool> LaunchWithPromptAsync(string prompt, CancellationToken cancellationToken = default);
+}

--- a/Solve/Services/IConsoleService.cs
+++ b/Solve/Services/IConsoleService.cs
@@ -1,0 +1,26 @@
+namespace Solve.Services;
+
+/// <summary>
+/// Service for console output with color support.
+/// </summary>
+public interface IConsoleService
+{
+    void WriteLine(string message = "");
+    void WriteInfo(string message);
+    void WriteSuccess(string message);
+    void WriteWarning(string message);
+    void WriteError(string message);
+    void WriteHeader(string message);
+    bool Confirm(string message);
+    string? Prompt(string message);
+
+    /// <summary>
+    /// Displays instructions for installing the GitHub CLI.
+    /// </summary>
+    void WriteGhInstallInstructions();
+
+    /// <summary>
+    /// Displays instructions for authenticating with the GitHub CLI.
+    /// </summary>
+    void WriteGhAuthInstructions();
+}

--- a/Solve/Services/IGitHubService.cs
+++ b/Solve/Services/IGitHubService.cs
@@ -1,0 +1,59 @@
+using Solve.Models;
+
+namespace Solve.Services;
+
+/// <summary>
+/// Service for GitHub operations via the gh CLI.
+/// </summary>
+public interface IGitHubService
+{
+    /// <summary>
+    /// Checks if the gh CLI is installed.
+    /// </summary>
+    Task<bool> IsInstalledAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Checks if the gh CLI is installed and authenticated.
+    /// </summary>
+    Task<bool> IsAuthenticatedAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets issue details.
+    /// </summary>
+    Task<GitHubIssue?> GetIssueAsync(string owner, string repo, int number, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets issue details using just the number (from current repo context).
+    /// </summary>
+    Task<GitHubIssue?> GetIssueAsync(int number, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Updates an issue's body.
+    /// </summary>
+    Task<bool> UpdateIssueBodyAsync(string owner, string repo, int number, string body, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the PR associated with the current branch.
+    /// </summary>
+    Task<(int Number, string Title, string Url)?> GetPullRequestForBranchAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Creates a pull request.
+    /// </summary>
+    Task<string?> CreatePullRequestAsync(string title, string body, string baseBranch, bool draft = false, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets unresolved review threads for a PR.
+    /// </summary>
+    Task<string?> GetPullRequestReviewsAsync(string owner, string repo, int prNumber, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the contents of a file from a GitHub repository.
+    /// </summary>
+    /// <param name="owner">Repository owner</param>
+    /// <param name="repo">Repository name</param>
+    /// <param name="path">Path to the file</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>File contents or null if not found</returns>
+    Task<string?> GetFileContentsAsync(string owner, string repo, string path, CancellationToken cancellationToken = default);
+}

--- a/Solve/Services/IGitService.cs
+++ b/Solve/Services/IGitService.cs
@@ -1,0 +1,72 @@
+namespace Solve.Services;
+
+/// <summary>
+/// Service for Git operations.
+/// </summary>
+public interface IGitService
+{
+    /// <summary>
+    /// Gets the current branch name.
+    /// </summary>
+    Task<string?> GetCurrentBranchAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the default branch name (main, master, development, etc.).
+    /// </summary>
+    Task<string?> GetDefaultBranchAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Checks if a branch exists locally or remotely.
+    /// </summary>
+    Task<bool> BranchExistsAsync(string branchName, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Finds branches matching a pattern.
+    /// </summary>
+    Task<List<string>> FindBranchesAsync(string pattern, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Switches to a branch.
+    /// </summary>
+    Task<bool> CheckoutAsync(string branchName, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Creates a new branch and switches to it.
+    /// </summary>
+    Task<bool> CreateBranchAsync(string branchName, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Fetches from remote.
+    /// </summary>
+    Task<bool> FetchAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Pulls latest changes.
+    /// </summary>
+    Task<bool> PullAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Pushes to remote with upstream tracking.
+    /// </summary>
+    Task<bool> PushAsync(bool setUpstream = false, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the remote URL to extract owner/repo.
+    /// </summary>
+    Task<(string? Owner, string? Repo)> GetRemoteInfoAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Checks if there are uncommitted changes.
+    /// </summary>
+    Task<bool> HasUncommittedChangesAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the commit log between two refs.
+    /// </summary>
+    Task<string?> GetLogAsync(string baseRef, string headRef = "HEAD", CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the diff between two refs.
+    /// </summary>
+    Task<string?> GetDiffAsync(string baseRef, string headRef = "HEAD", CancellationToken cancellationToken = default);
+}

--- a/Solve/Services/IPrdGenerator.cs
+++ b/Solve/Services/IPrdGenerator.cs
@@ -1,0 +1,54 @@
+using Solve.Models;
+
+namespace Solve.Services;
+
+/// <summary>
+/// Service for generating PRD and development plan documents.
+/// </summary>
+public interface IPrdGenerator
+{
+    /// <summary>
+    /// Generates a development plan document.
+    /// </summary>
+    Task<string> GeneratePlanAsync(GitHubIssue issue, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Generates a PRD document.
+    /// </summary>
+    Task<string> GeneratePrdAsync(GitHubIssue issue, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Saves the development plan to the standard location.
+    /// </summary>
+    Task<string> SavePlanAsync(int issueNumber, string content, bool force = false, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Saves the PRD to the standard location.
+    /// </summary>
+    Task<string> SavePrdAsync(int issueNumber, string content, bool force = false, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Checks if a plan exists for the issue.
+    /// </summary>
+    bool PlanExists(int issueNumber);
+
+    /// <summary>
+    /// Checks if a PRD exists for the issue.
+    /// </summary>
+    bool PrdExists(int issueNumber);
+
+    /// <summary>
+    /// Gets the plan file path for an issue.
+    /// </summary>
+    string GetPlanPath(int issueNumber);
+
+    /// <summary>
+    /// Gets the PRD file path for an issue.
+    /// </summary>
+    string GetPrdPath(int issueNumber);
+
+    /// <summary>
+    /// Reads and parses the PRD to get work status.
+    /// </summary>
+    Task<WorkStatus?> ParseWorkStatusAsync(int issueNumber, string issueTitle, CancellationToken cancellationToken = default);
+}

--- a/Solve/Services/PrdGenerator.cs
+++ b/Solve/Services/PrdGenerator.cs
@@ -1,0 +1,329 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.DependencyInjection;
+using MintPlayer.SourceGenerators.Attributes;
+using Solve.Models;
+
+namespace Solve.Services;
+
+[Register(typeof(IPrdGenerator), ServiceLifetime.Scoped, "SolveServices")]
+public partial class PrdGenerator : IPrdGenerator
+{
+    private const string PlansDirectory = ".claude/plans";
+    private const string DocsDirectory = "docs";
+
+    public Task<string> GeneratePlanAsync(GitHubIssue issue, CancellationToken cancellationToken = default)
+    {
+        var sb = new StringBuilder();
+
+        sb.AppendLine($"# Development Plan: Issue #{issue.Number}");
+        sb.AppendLine();
+        sb.AppendLine($"**Issue**: #{issue.Number}");
+        sb.AppendLine($"**Title**: {issue.Title}");
+        sb.AppendLine($"**Type**: {issue.GetIssueType()}");
+        sb.AppendLine($"**Priority**: {issue.GetPriority()}");
+        sb.AppendLine();
+        sb.AppendLine("## Executive Summary");
+        sb.AppendLine();
+        sb.AppendLine(ExtractSummary(issue.Body));
+        sb.AppendLine();
+        sb.AppendLine("---");
+        sb.AppendLine();
+        sb.AppendLine("## Problem Statement");
+        sb.AppendLine();
+        sb.AppendLine("### Current Behavior");
+        sb.AppendLine("<What currently happens>");
+        sb.AppendLine();
+        sb.AppendLine("### Expected Behavior");
+        sb.AppendLine("<What should happen after implementation>");
+        sb.AppendLine();
+        sb.AppendLine("### Impact");
+        sb.AppendLine("<Business/user impact>");
+        sb.AppendLine();
+        sb.AppendLine("---");
+        sb.AppendLine();
+        sb.AppendLine("## Technical Analysis");
+        sb.AppendLine();
+        sb.AppendLine("### Files to Modify");
+        sb.AppendLine("<List of files that need changes>");
+        sb.AppendLine();
+        sb.AppendLine("### Dependencies");
+        sb.AppendLine("<External services, packages, or other issues this depends on>");
+        sb.AppendLine();
+        sb.AppendLine("### Architecture Considerations");
+        sb.AppendLine("<Any architectural decisions or patterns to follow>");
+        sb.AppendLine();
+        sb.AppendLine("---");
+        sb.AppendLine();
+        sb.AppendLine("## Implementation Plan");
+        sb.AppendLine();
+        sb.AppendLine("### Phase 1: Initial Implementation");
+        sb.AppendLine("1. <Step 1>");
+        sb.AppendLine("2. <Step 2>");
+        sb.AppendLine();
+        sb.AppendLine("### Phase 2: Testing & Refinement");
+        sb.AppendLine("1. <Step 1>");
+        sb.AppendLine("2. <Step 2>");
+        sb.AppendLine();
+        sb.AppendLine("---");
+        sb.AppendLine();
+        sb.AppendLine("## Test Scenarios");
+        sb.AppendLine();
+        sb.AppendLine("### Scenario 1: Happy Path");
+        sb.AppendLine("- **Given**: <preconditions>");
+        sb.AppendLine("- **When**: <action>");
+        sb.AppendLine("- **Then**: <expected result>");
+        sb.AppendLine();
+        sb.AppendLine("---");
+        sb.AppendLine();
+        sb.AppendLine("## Acceptance Criteria");
+        sb.AppendLine();
+        ExtractAcceptanceCriteria(issue.Body, sb);
+        sb.AppendLine();
+        sb.AppendLine("---");
+        sb.AppendLine();
+        sb.AppendLine("## Related Files");
+        sb.AppendLine();
+        sb.AppendLine("- <file1>");
+        sb.AppendLine("- <file2>");
+
+        return Task.FromResult(sb.ToString());
+    }
+
+    public Task<string> GeneratePrdAsync(GitHubIssue issue, CancellationToken cancellationToken = default)
+    {
+        var sb = new StringBuilder();
+        var now = DateTime.Now.ToString("yyyy-MM-dd");
+
+        sb.AppendLine($"# Product Requirements Document: {issue.Title}");
+        sb.AppendLine();
+        sb.AppendLine($"**Issue**: #{issue.Number}");
+        sb.AppendLine($"**Title**: {issue.Title}");
+        sb.AppendLine("**Status**: Draft");
+        sb.AppendLine($"**Created**: {now}");
+        sb.AppendLine($"**Last Updated**: {now}");
+        sb.AppendLine();
+        sb.AppendLine("---");
+        sb.AppendLine();
+        sb.AppendLine("## Overview");
+        sb.AppendLine();
+        sb.AppendLine(ExtractSummary(issue.Body));
+        sb.AppendLine();
+        sb.AppendLine("---");
+        sb.AppendLine();
+        sb.AppendLine("## Goals & Objectives");
+        sb.AppendLine();
+        sb.AppendLine("### Primary Goals");
+        sb.AppendLine("- <Goal 1>");
+        sb.AppendLine("- <Goal 2>");
+        sb.AppendLine();
+        sb.AppendLine("### Success Metrics");
+        sb.AppendLine("- <Metric 1>");
+        sb.AppendLine("- <Metric 2>");
+        sb.AppendLine();
+        sb.AppendLine("---");
+        sb.AppendLine();
+        sb.AppendLine("## Functional Requirements");
+        sb.AppendLine();
+        sb.AppendLine("### Must Have (P0)");
+        sb.AppendLine("- [ ] **FR-1**: <requirement>");
+        sb.AppendLine("- [ ] **FR-2**: <requirement>");
+        sb.AppendLine();
+        sb.AppendLine("### Should Have (P1)");
+        sb.AppendLine("- [ ] **FR-3**: <requirement>");
+        sb.AppendLine();
+        sb.AppendLine("---");
+        sb.AppendLine();
+        sb.AppendLine("## Timeline & Milestones");
+        sb.AppendLine();
+        sb.AppendLine("### Milestone 1: Initial Implementation");
+        sb.AppendLine("- [ ] Task 1");
+        sb.AppendLine("- [ ] Task 2");
+        sb.AppendLine();
+        sb.AppendLine("### Milestone 2: Testing & Refinement");
+        sb.AppendLine("- [ ] Task 3");
+        sb.AppendLine();
+        sb.AppendLine("---");
+        sb.AppendLine();
+        sb.AppendLine("## Open Questions");
+        sb.AppendLine();
+        sb.AppendLine("- [ ] <Question 1>");
+        sb.AppendLine("- [ ] <Question 2>");
+        sb.AppendLine();
+        sb.AppendLine("---");
+        sb.AppendLine();
+        sb.AppendLine("## Technical Notes (Issue-Specific)");
+        sb.AppendLine();
+        sb.AppendLine("<Only include notes specific to THIS issue>");
+        sb.AppendLine();
+        sb.AppendLine("---");
+        sb.AppendLine();
+        sb.AppendLine("## Related");
+        sb.AppendLine($"- Issue #{issue.Number}");
+
+        return Task.FromResult(sb.ToString());
+    }
+
+    public async Task<string> SavePlanAsync(int issueNumber, string content, bool force = false, CancellationToken cancellationToken = default)
+    {
+        var path = GetPlanPath(issueNumber);
+
+        if (File.Exists(path) && !force)
+            throw new InvalidOperationException($"Plan already exists at {path}. Use --force to overwrite.");
+
+        var directory = Path.GetDirectoryName(path);
+        if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+            Directory.CreateDirectory(directory);
+
+        await File.WriteAllTextAsync(path, content, cancellationToken);
+        return path;
+    }
+
+    public async Task<string> SavePrdAsync(int issueNumber, string content, bool force = false, CancellationToken cancellationToken = default)
+    {
+        var path = GetPrdPath(issueNumber);
+
+        if (File.Exists(path) && !force)
+            throw new InvalidOperationException($"PRD already exists at {path}. Use --force to overwrite.");
+
+        var directory = Path.GetDirectoryName(path);
+        if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+            Directory.CreateDirectory(directory);
+
+        await File.WriteAllTextAsync(path, content, cancellationToken);
+        return path;
+    }
+
+    public bool PlanExists(int issueNumber) => File.Exists(GetPlanPath(issueNumber));
+
+    public bool PrdExists(int issueNumber) => File.Exists(GetPrdPath(issueNumber));
+
+    public string GetPlanPath(int issueNumber) => Path.Combine(PlansDirectory, $"issue_{issueNumber}.md");
+
+    public string GetPrdPath(int issueNumber) => Path.Combine(DocsDirectory, $"issue_{issueNumber}_PRD.md");
+
+    public async Task<WorkStatus?> ParseWorkStatusAsync(int issueNumber, string issueTitle, CancellationToken cancellationToken = default)
+    {
+        var prdPath = GetPrdPath(issueNumber);
+        if (!File.Exists(prdPath))
+            return null;
+
+        var content = await File.ReadAllTextAsync(prdPath, cancellationToken);
+        var status = new WorkStatus
+        {
+            IssueNumber = issueNumber,
+            IssueTitle = issueTitle
+        };
+
+        // Extract PRD status
+        var statusMatch = PrdStatusRegex().Match(content);
+        if (statusMatch.Success)
+            status.PrdStatus = statusMatch.Groups[1].Value.Trim();
+
+        // Count requirements
+        var checkedMatches = CheckedItemRegex().Matches(content);
+        var uncheckedMatches = UncheckedItemRegex().Matches(content);
+
+        status.CompletedRequirements = checkedMatches.Count;
+        status.TotalRequirements = checkedMatches.Count + uncheckedMatches.Count;
+
+        // Extract completed items
+        foreach (Match match in checkedMatches)
+        {
+            status.CompletedItems.Add(match.Groups[1].Value.Trim());
+        }
+
+        // Extract remaining items
+        foreach (Match match in uncheckedMatches)
+        {
+            status.RemainingItems.Add(match.Groups[1].Value.Trim());
+        }
+
+        // Extract open questions (unchecked items in Open Questions section)
+        var questionsSection = OpenQuestionsSectionRegex().Match(content);
+        if (questionsSection.Success)
+        {
+            var questionMatches = UncheckedItemRegex().Matches(questionsSection.Groups[1].Value);
+            foreach (Match match in questionMatches)
+            {
+                status.OpenQuestions.Add(match.Groups[1].Value.Trim());
+            }
+        }
+
+        // Determine implementation status
+        status.ImplementationStatus = status.CompletionPercentage switch
+        {
+            0 => "Not Started",
+            100 => "Complete",
+            _ => $"{status.CompletionPercentage}% Complete"
+        };
+
+        return status;
+    }
+
+    private static string ExtractSummary(string body)
+    {
+        if (string.IsNullOrWhiteSpace(body))
+            return "<Brief description of what needs to be done and why>";
+
+        // Take first paragraph or first 200 characters
+        var lines = body.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        var summary = new StringBuilder();
+
+        foreach (var line in lines)
+        {
+            var trimmed = line.Trim();
+            if (trimmed.StartsWith('#') || trimmed.StartsWith('-') || trimmed.StartsWith('*'))
+                continue;
+
+            summary.AppendLine(trimmed);
+            if (summary.Length > 200)
+                break;
+        }
+
+        var result = summary.ToString().Trim();
+        return string.IsNullOrEmpty(result)
+            ? "<Brief description of what needs to be done and why>"
+            : result;
+    }
+
+    private static void ExtractAcceptanceCriteria(string body, StringBuilder sb)
+    {
+        if (string.IsNullOrWhiteSpace(body))
+        {
+            sb.AppendLine("- [ ] <Criterion 1>");
+            sb.AppendLine("- [ ] <Criterion 2>");
+            return;
+        }
+
+        // Look for existing checkboxes in the body
+        var checkboxMatches = CheckboxRegex().Matches(body);
+        if (checkboxMatches.Count > 0)
+        {
+            foreach (Match match in checkboxMatches)
+            {
+                sb.AppendLine($"- [ ] {match.Groups[1].Value.Trim()}");
+            }
+        }
+        else
+        {
+            sb.AppendLine("- [ ] <Criterion 1>");
+            sb.AppendLine("- [ ] <Criterion 2>");
+        }
+    }
+
+    [GeneratedRegex(@"\*\*Status\*\*:\s*(.+)")]
+    private static partial Regex PrdStatusRegex();
+
+    [GeneratedRegex(@"- \[x\] (.+)")]
+    private static partial Regex CheckedItemRegex();
+
+    [GeneratedRegex(@"- \[ \] (.+)")]
+    private static partial Regex UncheckedItemRegex();
+
+    [GeneratedRegex(@"## Open Questions\s+([\s\S]*?)(?=\n##|$)")]
+    private static partial Regex OpenQuestionsSectionRegex();
+
+    [GeneratedRegex(@"- \[[ x]\] (.+)")]
+    private static partial Regex CheckboxRegex();
+}

--- a/Solve/Solve.csproj
+++ b/Solve/Solve.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net10.0</TargetFramework>
+		<LangVersion>14</LangVersion>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<Version>10.0.0</Version>
+		<IsPackable>true</IsPackable>
+		<EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+	</PropertyGroup>
+
+	<PropertyGroup>
+		<PackAsTool>true</PackAsTool>
+		<ToolCommandName>solve</ToolCommandName>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
+		<PackageReference Include="System.CommandLine" Version="2.0.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\SourceGenerators\SourceGenerators\MintPlayer.SourceGenerators\MintPlayer.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="true" />
+		<ProjectReference Include="..\SourceGenerators\SourceGenerators\MintPlayer.SourceGenerators.Attributes\MintPlayer.SourceGenerators.Attributes.csproj" />
+		<ProjectReference Include="..\SourceGenerators\Cli\MintPlayer.CliGenerator\MintPlayer.CliGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="true" />
+		<ProjectReference Include="..\SourceGenerators\Cli\MintPlayer.CliGenerator.Attributes\MintPlayer.CliGenerator.Attributes.csproj" />
+	</ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- Add new `solve` CLI tool that streamlines delegating GitHub issues to Claude Code
- Automates branch creation, PRD generation, Claude Code launching, and PR creation
- Supports PR templates from local repository and organization-level `.github` repo
- Includes comprehensive guidance when `gh` CLI is not installed or authenticated

## Commands
| Command | Description |
|---------|-------------|
| `solve <issue-url>` | Full workflow (init + prd + work) |
| `solve init <issue-url>` | Initialize branch for an issue |
| `solve prd` | Generate PRD and development plan |
| `solve work` | Start/continue working with Claude Code |
| `solve status` | Show work status for current issue |
| `solve pr` | Create pull request with template support |
| `solve feedback` | Review and resolve PR feedback |

## Features
- Auto-detection of issue number from branch name (`issues/123-description`)
- PR template support (checks local repo, then org-level `.github` repo)
- Placeholder substitution in PR templates
- Auto-checking PR type checkboxes
- Uses `MintPlayer.CliGenerator` for CLI parsing
- Uses `MintPlayer.SourceGenerators` `[Inject]` attribute for DI

## Test plan
- [ ] Build the project: `dotnet build Solve/Solve.csproj`
- [ ] Test `solve --help` shows all commands
- [ ] Test `solve init` with a GitHub issue URL
- [ ] Test `solve prd` generates PRD and plan files
- [ ] Test `solve pr` creates a pull request

🤖 Generated with [Claude Code](https://claude.com/claude-code)