### PR TITLE
feat: Add record type support to Mapper source generator

### DIFF
--- a/SourceGenerators/Mapper/MintPlayer.Mapper/MintPlayer.Mapper.csproj
+++ b/SourceGenerators/Mapper/MintPlayer.Mapper/MintPlayer.Mapper.csproj
@@ -11,7 +11,7 @@
 	</Target>
 
 	<PropertyGroup>
-		<Version>10.13.0</Version>
+		<Version>10.14.0</Version>
 		<Authors>Pieterjan De Clippel</Authors>
 		<Company>MintPlayer</Company>
 		<Description>This package automatically generates mappers for you</Description>

--- a/SourceGenerators/Mapper/MintPlayer.Mapper/Models/ConstructorParameterInfo.cs
+++ b/SourceGenerators/Mapper/MintPlayer.Mapper/Models/ConstructorParameterInfo.cs
@@ -1,0 +1,11 @@
+using MintPlayer.ValueComparerGenerator.Attributes;
+
+namespace MintPlayer.Mapper.Models;
+
+[AutoValueComparer]
+public partial class ConstructorParameterInfo
+{
+    public string ParameterName { get; set; }
+    public string CorrespondingPropertyName { get; set; }
+    public string ParameterType { get; set; }
+}

--- a/SourceGenerators/Mapper/MintPlayer.Mapper/Models/TypeToMap.cs
+++ b/SourceGenerators/Mapper/MintPlayer.Mapper/Models/TypeToMap.cs
@@ -17,6 +17,8 @@ public partial class TypeToMap
     /// </summary>
     public string DeclaredTypeName { get; set; }
     public int DeclaredTypeAccessibility { get; set; }
+    public bool DeclaredTypeHasParameterlessConstructor { get; set; }
+    public ConstructorParameterInfo[] DeclaredTypePrimaryConstructorParameters { get; set; } = [];
     public PropertyDeclaration[] DeclaredProperties { get; set; } = [];
 
     /// <summary>
@@ -29,6 +31,8 @@ public partial class TypeToMap
     /// </summary>
     public string MappingTypeName { get; set; }
     public int MappingTypeAccessibility { get; set; }
+    public bool MappingTypeHasParameterlessConstructor { get; set; }
+    public ConstructorParameterInfo[] MappingTypePrimaryConstructorParameters { get; set; } = [];
     public PropertyDeclaration[] MappingProperties { get; set; } = [];
 
     public string PreferredMappingMethodName { get; set; }

--- a/SourceGenerators/MintPlayer.SourceGenerators.Tools/MintPlayer.SourceGenerators.Tools.csproj
+++ b/SourceGenerators/MintPlayer.SourceGenerators.Tools/MintPlayer.SourceGenerators.Tools.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<Version>10.14.0</Version>
+		<Version>10.15.0</Version>
 		<Authors>Pieterjan De Clippel</Authors>
 		<Company>MintPlayer</Company>
 		<Description>This package contains useful tools for building source generators</Description>

--- a/SourceGenerators/TestProjects/MapperDebugging/Program.cs
+++ b/SourceGenerators/TestProjects/MapperDebugging/Program.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 
 [assembly: GenerateMapper(typeof(Person), typeof(PersonDto), "Persoon")]
 [assembly: GenerateMapper(typeof(ContactInfo), typeof(ContactInfoDto), "MapTo")]
+[assembly: GenerateMapper(typeof(Product), typeof(ProductDto), "MapTo")]
 
 
 var person = new Person
@@ -26,6 +27,22 @@ var person = new Person
 };
 var dto = person.MapToPersonDto();
 var entity = dto.MapToPerson();
+
+// Record with primary constructor (no parameterless ctor)
+var product = new Product("Widget", 9.99m);
+var productDto = product.MapToProductDto();
+var productBack = productDto.MapToProduct();
+
+// Record with primary constructor + extra settable property
+var coord = new Coordinate(1.0, 2.0) { Label = "Origin" };
+var coordDto = coord.MapToCoordinateDto();
+var coordBack = coordDto.MapToCoordinate();
+
+// Record without primary constructor (parameterless, init-only properties)
+var tag = new Tag { Name = "Important", Color = "Red" };
+var tagDto = tag.MapToTagDto();
+var tagBack = tagDto.MapToTag();
+
 Debugger.Break();
 
 
@@ -169,4 +186,54 @@ public class ContactInfoDto
 
     [MapTo(nameof(ContactInfo.Value))]
     public string Waarde { get; set; }
+}
+
+// --- Record test scenarios ---
+
+// Scenario 1: Record with primary constructor (no parameterless ctor)
+public record Product(string Name, decimal Price);
+
+public class ProductDto
+{
+    [MapTo(nameof(Product.Name))]
+    public string Name { get; set; }
+
+    [MapTo(nameof(Product.Price))]
+    public decimal Price { get; set; }
+}
+
+// Scenario 2: Record with primary ctor + extra settable property
+[GenerateMapper(typeof(CoordinateDto))]
+public record Coordinate(double X, double Y)
+{
+    public string? Label { get; set; }
+}
+
+public class CoordinateDto
+{
+    [MapTo(nameof(Coordinate.X))]
+    public double X { get; set; }
+
+    [MapTo(nameof(Coordinate.Y))]
+    public double Y { get; set; }
+
+    [MapTo(nameof(Coordinate.Label))]
+    public string? Label { get; set; }
+}
+
+// Scenario 3: Record without primary constructor (uses init properties)
+[GenerateMapper(typeof(TagDto))]
+public record Tag
+{
+    public string Name { get; init; }
+    public string Color { get; init; }
+}
+
+public record TagDto
+{
+    [MapTo(nameof(Tag.Name))]
+    public string Name { get; init; }
+
+    [MapTo(nameof(Tag.Color))]
+    public string Color { get; init; }
 }


### PR DESCRIPTION
## Summary
- Adds C# record type support to the Mapper source generator, enabling mapping to/from records with primary constructors
- For records without a parameterless constructor, generates constructor-based instantiation with named arguments instead of object initializer syntax
- Records with extra settable properties beyond the primary constructor use a combination of constructor arguments + object initializer
- Adds `Record`/`RecordStruct` handling to `SymbolExtensions.GetPathSpec` in the shared `MintPlayer.SourceGenerators.Tools` infrastructure

## Changes
- **New**: `ConstructorParameterInfo` model for tracking primary constructor parameters
- **`TypeToMap`**: Added `HasParameterlessConstructor` and `PrimaryConstructorParameters` fields for both declared/mapping types
- **`MapperGenerator`**: Added `HasParameterlessConstructor()` and `GetPrimaryConstructorParameters()` helpers; both assembly-level and type-level discovery paths populate the new fields
- **`MapperGenerator.Producer`**: Extracted `GetPropertyValueExpression()` from `HandleProperty()` for reuse; added `WriteNewInstance()` that branches between object initializer and constructor-based instantiation
- **`SymbolExtensions`**: Added `RecordDeclarationSyntax` to `IsPartial` detection, added `Record`/`RecordStruct` to `EPathSpecType`, updated `OpenPathSpec()` to emit correct keywords
- **Version bumps**: `MintPlayer.Mapper` 10.13.0 → 10.14.0, `MintPlayer.SourceGenerators.Tools` 10.14.0 → 10.15.0

## Test scenarios (in MapperDebugging project)
- Record with primary constructor only (`Product`) → constructor call
- Record with primary constructor + extra settable property (`Coordinate`) → constructor + object initializer
- Record without primary constructor, init properties (`Tag`) → standard object initializer

## Test plan
- [x] Build succeeds with no errors
- [x] Runtime execution succeeds with no errors
- [x] Generated code verified for all 3 record scenarios
- [x] Existing class-based mapping still works unchanged
- [ ] Verify NuGet package builds correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)