### PR TITLE
feat: Generate = null default for nullable [Inject] params

### DIFF
--- a/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators.Attributes/MintPlayer.SourceGenerators.Attributes.csproj
+++ b/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators.Attributes/MintPlayer.SourceGenerators.Attributes.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<LangVersion>14</LangVersion>
-		<Version>10.16.1</Version>
+		<Version>10.17.0</Version>
 		<Authors>Pieterjan De Clippel</Authors>
 		<Company>MintPlayer</Company>
 		<Description>This package contains attributes for the source generators</Description>

--- a/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators/Generators/InjectSourceGenerator.Producer.cs
+++ b/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators/Generators/InjectSourceGenerator.Producer.cs
@@ -54,7 +54,9 @@ internal class InjectProducer : Producer, IDiagnosticReporter
                 // Add [Inject] fields
                 foreach (var dep in classInfo.InjectFields)
                 {
-                    constructorParams.Add($"{dep.Type} {dep.Name}");
+                    constructorParams.Add(dep.IsNullable
+                        ? $"{dep.Type} {dep.Name} = null"
+                        : $"{dep.Type} {dep.Name}");
                 }
 
                 // Add [Options] fields (injected as constructor params)

--- a/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators/Generators/InjectSourceGenerator.cs
+++ b/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators/Generators/InjectSourceGenerator.cs
@@ -182,7 +182,9 @@ public class InjectSourceGenerator : IncrementalGenerator
                 var fieldTypeSymbol = semanticModel.GetSymbolInfo(fieldType).Symbol as ITypeSymbol;
                 var fqn = fieldTypeSymbol?.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat.WithGenericsOptions(SymbolDisplayGenericsOptions.IncludeTypeParameters)) ?? string.Empty;
                 var name = field.Declaration.Variables.First().Identifier.Text;
-                result.Add(new Models.InjectField { Type = fqn, Name = name });
+                var isNullable = fieldTypeSymbol?.NullableAnnotation == NullableAnnotation.Annotated
+                              || field.Declaration.Type is NullableTypeSyntax;
+                result.Add(new Models.InjectField { Type = fqn, Name = name, IsNullable = isNullable });
             }
         }
 
@@ -199,7 +201,9 @@ public class InjectSourceGenerator : IncrementalGenerator
                 var propTypeSymbol = semanticModel.GetSymbolInfo(prop.Type).Symbol as ITypeSymbol;
                 var fqn = propTypeSymbol?.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat.WithGenericsOptions(SymbolDisplayGenericsOptions.IncludeTypeParameters)) ?? string.Empty;
                 var name = prop.Identifier.Text;
-                result.Add(new Models.InjectField { Type = fqn, Name = name });
+                var isNullable = propTypeSymbol?.NullableAnnotation == NullableAnnotation.Annotated
+                              || prop.Type is NullableTypeSyntax;
+                result.Add(new Models.InjectField { Type = fqn, Name = name, IsNullable = isNullable });
             }
         }
 

--- a/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators/Generators/InjectSourceGenerator.cs
+++ b/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators/Generators/InjectSourceGenerator.cs
@@ -179,7 +179,7 @@ public class InjectSourceGenerator : IncrementalGenerator
                 .Any(attr => semanticModel.GetTypeInfo(attr).Type?.Name == "InjectAttribute"))
             {
                 var fieldType = field.Declaration.Type;
-                var fieldTypeSymbol = semanticModel.GetSymbolInfo(fieldType).Symbol as ITypeSymbol;
+                var fieldTypeSymbol = semanticModel.GetTypeInfo(fieldType).Type;
                 var fqn = fieldTypeSymbol?.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat.WithGenericsOptions(SymbolDisplayGenericsOptions.IncludeTypeParameters)) ?? string.Empty;
                 var name = field.Declaration.Variables.First().Identifier.Text;
                 var isNullable = fieldTypeSymbol?.NullableAnnotation == NullableAnnotation.Annotated
@@ -198,7 +198,7 @@ public class InjectSourceGenerator : IncrementalGenerator
                 var hasSetter = prop.AccessorList?.Accessors.Any(a => a.Kind() == SyntaxKind.SetAccessorDeclaration) == true;
                 if (hasSetter) continue;
 
-                var propTypeSymbol = semanticModel.GetSymbolInfo(prop.Type).Symbol as ITypeSymbol;
+                var propTypeSymbol = semanticModel.GetTypeInfo(prop.Type).Type;
                 var fqn = propTypeSymbol?.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat.WithGenericsOptions(SymbolDisplayGenericsOptions.IncludeTypeParameters)) ?? string.Empty;
                 var name = prop.Identifier.Text;
                 var isNullable = propTypeSymbol?.NullableAnnotation == NullableAnnotation.Annotated

--- a/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators/MintPlayer.SourceGenerators.csproj
+++ b/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators/MintPlayer.SourceGenerators.csproj
@@ -13,7 +13,7 @@
 	</Target>
 
 	<PropertyGroup>
-		<Version>10.16.1</Version>
+		<Version>10.17.0</Version>
 		<Authors>Pieterjan De Clippel</Authors>
 		<Company>MintPlayer</Company>
 		<Description>This package contains several source generators</Description>

--- a/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators/Models/InjectField.cs
+++ b/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators/Models/InjectField.cs
@@ -7,4 +7,5 @@ public partial class InjectField
 {
     public string? Type { get; set; }
     public string? Name { get; set; }
+    public bool IsNullable { get; set; }
 }

--- a/SourceGenerators/TestProjects/MintPlayer.SourceGenerators.Debug/Program.cs
+++ b/SourceGenerators/TestProjects/MintPlayer.SourceGenerators.Debug/Program.cs
@@ -95,6 +95,15 @@ public partial struct NestedStruct1
 }
 
 /// <summary>
+/// Demonstrates nullable [Inject] fields generating optional constructor parameters with = null default.
+/// </summary>
+public partial class NullableInjectDemo
+{
+    [Inject] private readonly ITestService1 requiredService;
+    [Inject] private readonly ITestService2? optionalService;
+}
+
+/// <summary>
 /// Demonstrates the [PostConstruct] attribute functionality.
 /// The OnInitialized method will be called automatically after
 /// all injected fields are assigned in the generated constructor.


### PR DESCRIPTION
## Summary
- When an `[Inject]`-decorated field/property has a nullable type annotation (e.g. `IService?`), the generated constructor parameter now includes `= null`, making the dependency truly optional at the DI container level
- Adds `IsNullable` property to `InjectField` model, capturing `NullableAnnotation` from the semantic model (same pattern already used by `ConfigField`)
- Non-nullable `[Inject]` fields remain required constructor parameters (no change)

## Test plan
- [x] Added `NullableInjectDemo` test class to debug project with both required and nullable inject fields
- [x] Verified generated output: `public NullableInjectDemo(global::ITestService1 requiredService, global::ITestService2 optionalService = null)`
- [x] Full build of debug test project succeeds with no new warnings
- [ ] Verify existing tests still pass (all non-nullable inject fields unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)