### PR TITLE
fix: Remove Microsoft.CodeAnalysis metapackage to resolve RS1038

### DIFF
--- a/SourceGenerators/MintPlayer.SourceGenerators.Tools/MintPlayer.SourceGenerators.Tools.csproj
+++ b/SourceGenerators/MintPlayer.SourceGenerators.Tools/MintPlayer.SourceGenerators.Tools.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<Version>10.15.0</Version>
+		<Version>10.16.0</Version>
 		<Authors>Pieterjan De Clippel</Authors>
 		<Company>MintPlayer</Company>
 		<Description>This package contains useful tools for building source generators</Description>
@@ -37,7 +37,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.CodeAnalysis" Version="4.14.0" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
 		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
 	</ItemGroup>

--- a/SourceGenerators/MintPlayer.SourceGenerators.Tools/Targets/sourcegenerator_tools.props
+++ b/SourceGenerators/MintPlayer.SourceGenerators.Tools/Targets/sourcegenerator_tools.props
@@ -19,7 +19,6 @@
 	<Choose>
 		<When Condition="$(RoslynVersion) == 'roslyn4.0'">
 			<ItemGroup>
-				<PackageReference Include="Microsoft.CodeAnalysis" Version="4.14.0" PrivateAssets="all" />
 				<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" PrivateAssets="all" />
 				<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
 				<!--<PackageReference Include="Microsoft.CodeAnalysis.Features" Version="4.0.1" PrivateAssets="all" />-->
@@ -30,7 +29,6 @@
 		</When>
 		<Otherwise>
 			<ItemGroup>
-				<PackageReference Include="Microsoft.CodeAnalysis" Version="4.14.0" PrivateAssets="all" />
 				<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" PrivateAssets="all" />
 				<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
 				<!--<PackageReference Include="Microsoft.CodeAnalysis.Features" Version="4.9.2" PrivateAssets="all" />-->


### PR DESCRIPTION
## Summary
- Remove `Microsoft.CodeAnalysis` metapackage reference from `MintPlayer.SourceGenerators.Tools.csproj` and the distributed `sourcegenerator_tools.props`
- Keep `Microsoft.CodeAnalysis.CSharp` which already transitively provides `Microsoft.CodeAnalysis.Common`
- Bump `MintPlayer.SourceGenerators.Tools` version to **10.16.0**

## Problem
The `Microsoft.CodeAnalysis` metapackage transitively pulls in:
- `Microsoft.CodeAnalysis.CSharp.Workspaces`
- `Microsoft.CodeAnalysis.VisualBasic.Workspaces`
- `Microsoft.CodeAnalysis.Workspaces.Common`

These Workspaces assemblies are **not available** in Visual Studio's analyzer host process. This causes **RS1038** warnings in consumer source generator projects (e.g. `MintPlayer.Spark.SourceGenerators`), and prevents Visual Studio from loading those generators.

The Tools library itself does not use any Workspaces or VisualBasic types — only core `Microsoft.CodeAnalysis.Common` and `Microsoft.CodeAnalysis.CSharp` types.

## Test plan
- [x] `MintPlayer.SourceGenerators.Tools` builds without errors
- [x] No Workspaces/VisualBasic transitive dependencies in `dotnet list package --include-transitive`
- [ ] Consumer source generators (e.g. MintPlayer.Spark.SourceGenerators) no longer produce RS1038 warnings
- [ ] Source generators load and run correctly in Visual Studio

🤖 Generated with [Claude Code](https://claude.com/claude-code)