### PR TITLE
fix: Firefox + Belgian eID mTLS hang via nginx terminator

### DIFF
--- a/.github/workflows/eid-deploy.yml
+++ b/.github/workflows/eid-deploy.yml
@@ -74,18 +74,17 @@ jobs:
           passphrase: ${{ secrets.VPS_SSH_KEY_PASSPHRASE }}
           envs: GITHUB_TOKEN
           script: |
-            mkdir -p /var/www/${{ env.APP_NAME }}
+            mkdir -p /var/www/${{ env.APP_NAME }}/traefik-dynamic-config
             cd /var/www/${{ env.APP_NAME }}
 
-            # Download latest docker-compose.yml from the repository
-            rm -f docker-compose.yml
+            # Download docker-compose.yml + nginx.conf + CA bundle for nginx-eid
+            rm -f docker-compose.yml nginx.conf
             curl -sf -H "Authorization: token $GITHUB_TOKEN" -o docker-compose.yml https://raw.githubusercontent.com/${{ github.repository }}/master/Beid/DemoWebApp/docker-compose.yml
+            curl -sf -H "Authorization: token $GITHUB_TOKEN" -o nginx.conf https://raw.githubusercontent.com/${{ github.repository }}/master/Beid/DemoWebApp/nginx.conf
+            curl -sf -H "Authorization: token $GITHUB_TOKEN" -o traefik-dynamic-config/belgian-eid-cas.pem https://raw.githubusercontent.com/${{ github.repository }}/master/Beid/DemoWebApp/traefik-dynamic-config/belgian-eid-cas.pem
 
-            # Ensure Traefik mTLS dynamic config is present
-            mkdir -p /var/www/traefik/dynamic
-            curl -sf -H "Authorization: token $GITHUB_TOKEN" -o /var/www/traefik/dynamic/tls.yml https://raw.githubusercontent.com/${{ github.repository }}/master/Beid/DemoWebApp/traefik-dynamic-config/tls.yml
-            curl -sf -H "Authorization: token $GITHUB_TOKEN" -o /var/www/traefik/dynamic/belgium-root-ca4.pem https://raw.githubusercontent.com/${{ github.repository }}/master/Beid/DemoWebApp/traefik-dynamic-config/belgium-root-ca4.pem
-            curl -sf -H "Authorization: token $GITHUB_TOKEN" -o /var/www/traefik/dynamic/citizen-ca.pem https://raw.githubusercontent.com/${{ github.repository }}/master/Beid/DemoWebApp/traefik-dynamic-config/citizen-ca.pem
+            # Ensure cert-dump destination exists (populated by traefik-certs-dumper, mounted by nginx-eid)
+            mkdir -p /var/www/traefik/dumped-certs
 
             # Log in to GHCR using the workflow's GITHUB_TOKEN
             echo "$GITHUB_TOKEN" | docker login ghcr.io -u ${{ github.actor }} --password-stdin

--- a/Beid/DemoWebApp/FIREFOX-MTLS-PSS-ROOTCAUSE.md
+++ b/Beid/DemoWebApp/FIREFOX-MTLS-PSS-ROOTCAUSE.md
@@ -1,0 +1,122 @@
+# Firefox + Belgian eID mTLS Hang: Root Cause Analysis
+
+**Date:** 2026-04-28
+**App:** Belgian eID DemoWebApp (`eid.mintplayer.com`, also `https://localhost:5050` locally)
+**Status:** Diagnosed; fix not yet implemented
+
+---
+
+## Symptom
+
+Connecting to the app with a Belgian eID card:
+
+- **Chrome (Windows):** works. PIN prompt → enter PIN → `/todos` returns the expected JSON.
+- **Firefox (Windows):** PIN prompt appears, user enters PIN, page hangs ~2 minutes, then "De wachttijd voor de verbinding is verstreken" (connection timeout). No certificate error, no TLS alert displayed to the user.
+
+The hang reproduces against **both** the VPS deployment (Traefik / Go TLS) **and** the local development server (Kestrel / Schannel). It has never worked in Firefox.
+
+A previous PRD (`PRD-firefox-mtls-fix.md`) addressed an earlier-stage symptom (no PIN prompt at all) by adding `caFiles` and ALPN restrictions. Those fixes did get the PIN prompt to appear — but the hang after PIN entry is a separate problem with a different root cause.
+
+---
+
+## Root Cause: RSA-PSS in `signature_algorithms`
+
+Traefik (and Kestrel server-mode on Windows) advertises an mTLS `CertificateRequest` whose `signature_algorithms` extension lists **`rsa_pss_rsae_sha256` first**, with `rsa_pkcs1_sha256` only sixth:
+
+```
+signature_algorithms (len=20)
+  rsa_pss_rsae_sha256 (0x0804)   ← FIRST
+  ecdsa_secp256r1_sha256 (0x0403)
+  ed25519 (0x0807)
+  rsa_pss_rsae_sha384
+  rsa_pss_rsae_sha512
+  rsa_pkcs1_sha256 (0x0401)       ← only 6th
+  rsa_pkcs1_sha384
+  rsa_pkcs1_sha512
+  ecdsa_secp384r1_sha384
+  ecdsa_secp521r1_sha512
+```
+
+Captured live with `openssl s_client -connect eid.mintplayer.com:443 -tls1_2 -trace`.
+
+### Failure sequence in Firefox
+
+1. NSS picks the **first** scheme in the server's list whose key algorithm matches the chosen client cert. The eID auth cert is RSA-2048 → first match is `rsa_pss_rsae_sha256` (PSS).
+2. NSS calls `C_Sign` on the eID PKCS#11 module (`beidpkcs11.dll`) requesting an RSA-PSS signature.
+3. Belgian eID cards (especially the 2017-era card under test) **do not implement RSA-PSS signing** in their applet — they only support `RSASSA-PKCS1-v1_5`. The card returns `CKR_MECHANISM_INVALID`, or the middleware hangs the call.
+4. NSS does **not** fall back to a different signature scheme. The `CertificateVerify` is never produced. The TLS handshake stalls until the TCP connection times out.
+
+PSS support was only added on the card-applet side starting roughly with eID v1.9 / middleware 5.x in 2024. Any card issued before that — including this 2017 card — is PKCS#1 v1.5 only.
+
+### Why Chrome works
+
+Chrome on Windows uses **Schannel → MSCAPI → eID CSP**, not PKCS#11. The CSP advertises to MSCAPI only the algorithms the card actually supports (`RSASSA-PKCS1-v1_5`), so Schannel pre-filters PSS out of the negotiation and signs with PKCS#1 v1.5. Different code path entirely; the bug doesn't apply.
+
+### Why `taxonweb.be` works in Firefox with the same card
+
+Belgian government portals (CSAM, Itsme, etc.) use **federated SAML / OIDC**, not client-cert TLS. The eID is used after the TLS handshake completes — there is no `CertificateVerify` step on the card key during the handshake, so the PSS-vs-PKCS#1-v1_5 question never arises.
+
+### Why Kestrel local server fails the same way
+
+`Program.cs:86-103` configures Kestrel for development with `ClientCertificateMode.RequireCertificate`. The TLS handshake is performed by Schannel in server mode, which on modern Windows also advertises RSA-PSS first in `signature_algorithms`. Same root cause, different layer. (Kestrel additionally has no per-app `caFiles` equivalent, but that's a separate, smaller issue.)
+
+---
+
+## Why this can't be fixed in Traefik (or Caddy)
+
+Go's `crypto/tls` **hardcodes** the advertised list in `defaultSupportedSignatureAlgorithms` (in `crypto/tls/common.go`). `tls.Config` exposes no `SignatureAlgorithms` field. Traefik can't surface a knob that Go doesn't expose. Same applies to Caddy v2 (also Go).
+
+Tracking issue: [golang/go#45266](https://github.com/golang/go/issues/45266) — open, no movement.
+
+The `caFiles` and `alpnProtocols` fixes already in `traefik-dynamic-config/tls.yml` are still correct and necessary; they're just not sufficient.
+
+---
+
+## Fix Options
+
+### Option A — nginx as a TLS terminator for the `eid` router (recommended)
+
+Keep Traefik for everything else on the VPS. Add an `nginx-eid` container that handles **only** `eid.mintplayer.com`:
+
+- nginx (OpenSSL-backed) supports `ssl_conf_command SignatureAlgorithms RSA+SHA256:RSA+SHA384:RSA+SHA512;` which advertises **only** PKCS#1 v1.5 in the `CertificateRequest`. PSS is never offered, NSS never tries it.
+- nginx forwards the client cert to the .NET app exactly like Traefik does today (header containing PEM/DER), so `Program.cs` doesn't change.
+- Traefik can still handle the Let's Encrypt cert for the public TLS, with nginx terminating internally — or nginx can own its own ACME via certbot. Either layout works.
+
+Trade-off: one more container, slightly more deploy complexity.
+
+### Option B — HAProxy terminator
+
+Same idea as A. HAProxy also uses OpenSSL and supports `ssl-default-bind-options` + `SignatureAlgorithms`. Equivalent outcome; pick whichever the team is more comfortable operating.
+
+### Option C — "Chrome only" with a Firefox banner
+
+Detect Firefox on `/` and render a notice explaining the limitation. Smallest engineering cost; punts the problem to users. Reasonable if this app stays a demo.
+
+### Option D — Wait on Go
+
+Not a real option. The Go issue has been open since 2021 with no implementation progress.
+
+---
+
+## Recommendation
+
+Go with **Option A**. It is the only fix that makes Firefox work without changing per-user OS or browser configuration, and it isolates the workaround to one container that's clearly labeled as "Firefox-compatibility shim for Belgian eID mTLS." If/when Go fixes its `crypto/tls` API, the shim can be removed and Traefik can take the route back over.
+
+---
+
+## What's already in place (for context)
+
+- `traefik-dynamic-config/tls.yml`: `clientAuthType: RequestClientCert`, TLS 1.2 only, `alpnProtocols: [http/1.1]`, `caFiles: [belgium-root-ca4.pem, citizen-ca.pem]`. All correct, leave as-is.
+- `caFiles` matches the user's card issuer (`Citizen CA serialNumber=201701`, SHA1 `D1:2D:09:75:07:15:BC:5A:37:57:EA:62:04:5A:98:6D:BC:5A:F1:E9`) — verified by exporting the intermediate from the eID Viewer and comparing fingerprints.
+- Live `openssl s_client` confirms the server presents both CA names correctly and negotiates ALPN as `http/1.1`.
+- `passTLSClientCert` middleware + `CertificateForwarding` in `Program.cs` is correct and would be reused unchanged behind nginx.
+
+---
+
+## References
+
+- [golang/go#45266](https://github.com/golang/go/issues/45266) — proposal to expose `SignatureAlgorithms` on `tls.Config` (open, stalled)
+- [Mozilla Bug 1662607](https://bugzilla.mozilla.org/show_bug.cgi?id=1662607) — NSS doesn't fall back to alternate sig algs on client-cert signing failure
+- nginx [`ssl_conf_command`](https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_conf_command) — passthrough to OpenSSL config commands including `SignatureAlgorithms`
+- RFC 5246 §7.4.1.4.1 — TLS 1.2 `signature_algorithms` extension (server side controls the offered list)
+- Belgian eID middleware release notes — PSS support timeline

--- a/Beid/DemoWebApp/Program.cs
+++ b/Beid/DemoWebApp/Program.cs
@@ -103,16 +103,16 @@ public class Program
         }
         else
         {
-            // Behind Traefik: client cert is forwarded via header
+            // Behind nginx-eid: client cert is forwarded via header.
+            // nginx's $ssl_client_escaped_cert produces URL-encoded PEM (single leaf cert).
             builder.Services.AddCertificateForwarding(options =>
             {
                 options.CertificateHeader = "X-Forwarded-Tls-Client-Cert";
                 options.HeaderConverter = (headerValue) =>
                 {
-                    var decoded = Uri.UnescapeDataString(headerValue);
-                    var leafCertBase64 = decoded.Split(',')[0];
-                    var certBytes = Convert.FromBase64String(leafCertBase64);
-                    return X509CertificateLoader.LoadCertificate(certBytes);
+                    if (string.IsNullOrEmpty(headerValue)) return null!;
+                    var pem = Uri.UnescapeDataString(headerValue);
+                    return X509Certificate2.CreateFromPem(pem);
                 };
             });
         }

--- a/Beid/DemoWebApp/Readme.md
+++ b/Beid/DemoWebApp/Readme.md
@@ -83,11 +83,9 @@ In `/var/www/traefik/docker-compose.yml`, add alongside the `traefik` service:
     restart: unless-stopped
 ```
 
-Then `cd /var/www/traefik && docker compose up -d certs-dumper`.
-
 ### 2. Bootstrap the cert dump (run once)
 
-The watcher only writes new files when `acme.json` changes. To force an immediate one-time dump of the existing cert (avoids `nginx-eid` crash-looping on first deploy):
+Run a one-shot dump of the existing cert before starting the long-running watcher. This avoids `nginx-eid` crash-looping on first deploy:
 
 ```bash
 cd /var/www/traefik
@@ -97,15 +95,31 @@ docker compose run --rm certs-dumper file --version=v3 --source=/letsencrypt/acm
 Verify the result:
 
 ```bash
-ls -la /var/www/traefik/dumped-certs/letsencrypt/eid.mintplayer.com/
+ls -la /var/www/traefik/dumped-certs/eid.mintplayer.com/
 # expected:
-#   certificate.crt
-#   privatekey.key
+#   certificate.pem
+#   privatekey.pem
 ```
 
 `nginx-eid` mounts that directory directly (`docker-compose.yml:24`).
 
-### 3. Reload nginx-eid when the cert renews
+### 3. Start the long-running watcher
+
+```bash
+cd /var/www/traefik
+docker compose up -d certs-dumper
+```
+
+Confirm it's running:
+
+```bash
+docker compose ps certs-dumper
+# STATUS should be "Up"
+```
+
+This watches `acme.json` and re-dumps `certificate.pem` / `privatekey.pem` automatically whenever Traefik renews the cert.
+
+### 4. Reload nginx-eid when the cert renews
 
 Let's Encrypt certs are valid for 90 days; Traefik renews ~30 days before expiry. The dumper writes new files immediately, but nginx loads its cert at startup — it needs `nginx -s reload` to pick up the new file. Pick **one** of:
 
@@ -142,7 +156,7 @@ And add labels to `nginx-eid`:
 
 Fully declarative, no host crontab.
 
-### 4. Confirm `eid.mintplayer.com` resolves to your VPS
+### 5. Confirm `eid.mintplayer.com` resolves to your VPS
 
 DNS A record → VPS IP. (Already in place if the previous Traefik-terminated setup was working.)
 

--- a/Beid/DemoWebApp/Readme.md
+++ b/Beid/DemoWebApp/Readme.md
@@ -1,0 +1,168 @@
+# Belgian eID DemoWebApp
+
+ASP.NET Core demo that authenticates users with their Belgian eID smart card via mTLS, deployed at https://eid.mintplayer.com.
+
+After entering the card PIN in the browser, `/todos` returns the user's `PersonInfo` (firstNames, lastName, nationalNumber, validity dates) extracted from the auth certificate's subject DN.
+
+---
+
+## Architecture
+
+```
+Internet :443 (Traefik)
+   ├── SNI: bootstrap.mintplayer.com → terminate TLS → ng-bootstrap
+   ├── SNI: ... → terminate TLS → other containers
+   └── SNI: eid.mintplayer.com → TCP TLS PASSTHROUGH ─┐
+                                                       │ encrypted bytes
+                                                       ▼
+                                                  nginx-eid:443
+                                                  (terminates TLS, requests client cert,
+                                                   advertises only PKCS#1 v1.5 sig algs)
+                                                       │ HTTP + cert in X-Forwarded-Tls-Client-Cert
+                                                       ▼
+                                                   .NET eid:8080
+```
+
+**Why nginx instead of letting Traefik terminate TLS for this host?** Traefik (Go's `crypto/tls`) hardcodes `rsa_pss_rsae_sha256` first in the `CertificateRequest` `signature_algorithms`. Belgian eID cards cannot sign RSA-PSS, so Firefox+NSS picks PSS, fails, and hangs. nginx (OpenSSL) lets us override the list via `ssl_conf_command SignatureAlgorithms`. See [`FIREFOX-MTLS-PSS-ROOTCAUSE.md`](FIREFOX-MTLS-PSS-ROOTCAUSE.md) for the full diagnosis.
+
+Other Traefik-fronted apps on the same VPS are unaffected — only the `eid.mintplayer.com` SNI gets routed via TCP passthrough.
+
+---
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `Program.cs` | The .NET app. Local dev: Kestrel terminates TLS directly. Prod: reads the leaf cert (URL-encoded PEM) from `X-Forwarded-Tls-Client-Cert`. |
+| `docker-compose.yml` | Two services: `nginx-eid` (TLS+mTLS terminator, exposed via Traefik TCP passthrough) and `eid` (the .NET app, internal-only). |
+| `nginx.conf` | nginx config. Terminates TLS 1.2, requests client cert with `optional_no_ca`, sets `ssl_conf_command SignatureAlgorithms RSA+SHA256:RSA+SHA384:RSA+SHA512` so Firefox doesn't try PSS, forwards cert to `eid:8080`. |
+| `traefik-dynamic-config/belgian-eid-cas.pem` | Combined PEM of `Belgium Root CA4` + `Citizen CA serialNumber=201701`. Used by nginx as `ssl_client_certificate` (the names go into the `CertificateRequest` so browsers know which cert to offer). |
+| `Dockerfile` | Builds the .NET image published to `ghcr.io/mintplayer/mintplayer-dotnet-tools-eid`. |
+| `.github/workflows/eid-deploy.yml` | Builds the Docker image on every push to `master` (paths `Beid/DemoWebApp/**`), then SSHes to the VPS and runs `docker compose pull && up -d`. |
+
+### Companion docs
+
+- [`FIREFOX-MTLS-PSS-ROOTCAUSE.md`](FIREFOX-MTLS-PSS-ROOTCAUSE.md) — root-cause analysis of why Firefox hangs after PIN entry, and why the fix has to be at the TLS-terminator layer.
+- [`PRD-firefox-mtls-fix.md`](PRD-firefox-mtls-fix.md) — earlier PRD that addressed the *first* Firefox symptom (no PIN prompt at all) by adding `caFiles` and ALPN restrictions to Traefik. Those fixes are now superseded for this host but were correct for that earlier failure mode.
+- [`CLIENT-CERT-FORWARDING.md`](CLIENT-CERT-FORWARDING.md) — explains the `X-Forwarded-Tls-Client-Cert` header flow. Written when Traefik was the terminator; the .NET-side reading logic is unchanged with nginx, only the header-value format differs (URL-encoded PEM vs URL-encoded base64 DER).
+- [`Create-Certificate.md`](Create-Certificate.md) — local-dev cert generation notes.
+
+---
+
+## Local development
+
+`dotnet run` against the `http` launch profile — Kestrel listens on `https://localhost:5050` with `ClientCertificateMode.RequireCertificate` and a 2-minute handshake timeout (so PIN entry doesn't time out). See `Properties/launchSettings.json`.
+
+> **Note:** Firefox + Belgian eID does **not** work locally either, for the same PSS reason — Schannel in server mode also advertises PSS first. Use Chrome for local testing (it goes Schannel→MSCAPI→eID CSP, a different code path that filters PSS out).
+
+---
+
+## VPS one-time setup
+
+The GitHub Action handles app deployment on every push. The bits below are **one-time** infrastructure changes you do once on the VPS.
+
+### 1. Add `traefik-certs-dumper` sidecar to Traefik
+
+The eID app's nginx needs a TLS cert. Traefik already obtains one via Let's Encrypt (because of the phantom HTTP router in this app's docker-compose), but it lives inside Traefik's `acme.json`. The `traefik-certs-dumper` sidecar watches `acme.json` and writes the cert + key out as plain files that nginx-eid can mount.
+
+In `/var/www/traefik/docker-compose.yml`, add alongside the `traefik` service:
+
+```yaml
+  certs-dumper:
+    image: ldez/traefik-certs-dumper:latest
+    command:
+      - file
+      - --version=v3
+      - --watch
+      - --source=/letsencrypt/acme.json
+      - --dest=/dumped
+      - --domain-subdir=true
+    volumes:
+      - letsencrypt:/letsencrypt:ro
+      - /var/www/traefik/dumped-certs:/dumped
+    restart: unless-stopped
+```
+
+Then `cd /var/www/traefik && docker compose up -d certs-dumper`.
+
+### 2. Bootstrap the cert dump (run once)
+
+The watcher only writes new files when `acme.json` changes. To force an immediate one-time dump of the existing cert (avoids `nginx-eid` crash-looping on first deploy):
+
+```bash
+cd /var/www/traefik
+docker compose run --rm certs-dumper file --version=v3 --source=/letsencrypt/acme.json --dest=/dumped --domain-subdir=true
+```
+
+Verify the result:
+
+```bash
+ls -la /var/www/traefik/dumped-certs/letsencrypt/eid.mintplayer.com/
+# expected:
+#   certificate.crt
+#   privatekey.key
+```
+
+`nginx-eid` mounts that directory directly (`docker-compose.yml:24`).
+
+### 3. Reload nginx-eid when the cert renews
+
+Let's Encrypt certs are valid for 90 days; Traefik renews ~30 days before expiry. The dumper writes new files immediately, but nginx loads its cert at startup — it needs `nginx -s reload` to pick up the new file. Pick **one** of:
+
+**Option A — host cron** (simplest if you're comfortable with cron). Debian has cron running by default (`systemctl status cron`). As root:
+
+```bash
+sudo crontab -e
+# add this line:
+0 4 * * * docker exec nginx-eid nginx -s reload >/dev/null 2>&1
+```
+
+Daily at 04:00. Renewal happens once every ~60 days, so daily reload is overkill but harmless.
+
+**Option B — ofelia sidecar** (no host changes). Add to this app's `docker-compose.yml`:
+
+```yaml
+  ofelia:
+    image: mcuadros/ofelia:latest
+    command: daemon --docker
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    networks:
+      - web
+    restart: unless-stopped
+```
+
+And add labels to `nginx-eid`:
+
+```yaml
+      - "ofelia.enabled=true"
+      - "ofelia.job-exec.reload-nginx.schedule=0 0 4 * * *"
+      - "ofelia.job-exec.reload-nginx.command=nginx -s reload"
+```
+
+Fully declarative, no host crontab.
+
+### 4. Confirm `eid.mintplayer.com` resolves to your VPS
+
+DNS A record → VPS IP. (Already in place if the previous Traefik-terminated setup was working.)
+
+---
+
+## Verifying
+
+```bash
+# From outside the VPS — should show TLS 1.2, ALPN http/1.1, Acceptable CA names:
+echo Q | openssl s_client -connect eid.mintplayer.com:443 -tls1_2 2>&1 | grep -E "(CA names|ALPN|Cipher|Protocol|signature)"
+
+# From outside, with -trace, the CertificateRequest signature_algorithms should
+# now start with rsa_pkcs1_sha256 (NOT rsa_pss_rsae_sha256):
+echo Q | openssl s_client -connect eid.mintplayer.com:443 -tls1_2 -trace 2>&1 | grep -A 15 "signature_algorithms"
+```
+
+Browser test: insert eID, navigate to `https://eid.mintplayer.com/todos`, enter PIN. Should return JSON like:
+
+```json
+{"notBefore":"...","notAfter":"...","firstNames":"...","lastName":"...","nationalNumber":"...","country":"BE"}
+```
+
+In **both** Chrome and Firefox.

--- a/Beid/DemoWebApp/docker-compose.yml
+++ b/Beid/DemoWebApp/docker-compose.yml
@@ -1,14 +1,36 @@
 services:
-  eid:
-    image: ghcr.io/mintplayer/mintplayer-dotnet-tools-eid:master
+  nginx-eid:
+    image: nginx:alpine
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.eid.rule=Host(`eid.mintplayer.com`)"
-      - "traefik.http.routers.eid.entrypoints=websecure"
-      - "traefik.http.routers.eid.tls.certresolver=letsencrypt"
-      - "traefik.http.routers.eid.tls.options=mtls@file"
-      - "traefik.http.routers.eid.middlewares=eid-clientcert"
-      - "traefik.http.middlewares.eid-clientcert.passtlsclientcert.pem=true"
+
+      # TCP TLS passthrough router: SNI-routed encrypted bytes flow straight to nginx
+      - "traefik.tcp.routers.eid.rule=HostSNI(`eid.mintplayer.com`)"
+      - "traefik.tcp.routers.eid.entrypoints=websecure"
+      - "traefik.tcp.routers.eid.tls.passthrough=true"
+      - "traefik.tcp.routers.eid.service=eid"
+      - "traefik.tcp.services.eid.loadbalancer.server.port=443"
+
+      # Phantom HTTP router on websecure: never serves traffic (TCP router wins for this SNI),
+      # but its presence makes Traefik fetch a Let's Encrypt cert for eid.mintplayer.com.
+      # The cert is then extracted from acme.json by traefik-certs-dumper (see /var/www/traefik).
+      - "traefik.http.routers.eid-cert.rule=Host(`eid.mintplayer.com`)"
+      - "traefik.http.routers.eid-cert.entrypoints=websecure"
+      - "traefik.http.routers.eid-cert.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.eid-cert.service=eid-cert-noop"
+      - "traefik.http.services.eid-cert-noop.loadbalancer.server.port=443"
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./traefik-dynamic-config/belgian-eid-cas.pem:/etc/nginx/ca/eid-cas.pem:ro
+      - /var/www/traefik/dumped-certs/letsencrypt/eid.mintplayer.com:/etc/nginx/certs:ro
+    depends_on:
+      - eid
+    networks:
+      - web
+    restart: unless-stopped
+
+  eid:
+    image: ghcr.io/mintplayer/mintplayer-dotnet-tools-eid:master
     networks:
       - web
     restart: unless-stopped

--- a/Beid/DemoWebApp/docker-compose.yml
+++ b/Beid/DemoWebApp/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
       - ./traefik-dynamic-config/belgian-eid-cas.pem:/etc/nginx/ca/eid-cas.pem:ro
-      - /var/www/traefik/dumped-certs/letsencrypt/eid.mintplayer.com:/etc/nginx/certs:ro
+      - /var/www/traefik/dumped-certs/eid.mintplayer.com:/etc/nginx/certs:ro
     depends_on:
       - eid
     networks:

--- a/Beid/DemoWebApp/nginx.conf
+++ b/Beid/DemoWebApp/nginx.conf
@@ -1,0 +1,39 @@
+events {}
+
+http {
+    server {
+        listen 443 ssl;
+        server_name eid.mintplayer.com;
+
+        ssl_certificate     /etc/nginx/certs/certificate.crt;
+        ssl_certificate_key /etc/nginx/certs/privatekey.key;
+        ssl_protocols       TLSv1.2;
+
+        # The whole reason this nginx exists: advertise ONLY PKCS#1 v1.5 in the
+        # CertificateRequest signature_algorithms extension. Belgian eID cards
+        # cannot sign RSA-PSS, but Go's TLS (Traefik) hardcodes PSS first, so
+        # Firefox/NSS picks PSS, the card's PKCS#11 fails, and the handshake
+        # hangs. OpenSSL exposes the knob; Go does not.
+        # See: Beid/DemoWebApp/FIREFOX-MTLS-PSS-ROOTCAUSE.md
+        ssl_conf_command SignatureAlgorithms RSA+SHA256:RSA+SHA384:RSA+SHA512;
+
+        # mTLS: request the cert but don't reject when absent — the .NET app
+        # decides whether to return 401 based on the endpoint.
+        ssl_verify_client       optional_no_ca;
+        ssl_client_certificate  /etc/nginx/ca/eid-cas.pem;
+
+        location / {
+            proxy_pass         http://eid:8080;
+            proxy_http_version 1.1;
+            proxy_set_header   Host              $host;
+            proxy_set_header   X-Real-IP         $remote_addr;
+            proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto https;
+
+            # Same header name the .NET app already reads. nginx puts the
+            # URL-encoded PEM here (vs Traefik's URL-encoded base64 DER) —
+            # the HeaderConverter in Program.cs is updated to parse PEM.
+            proxy_set_header   X-Forwarded-Tls-Client-Cert $ssl_client_escaped_cert;
+        }
+    }
+}

--- a/Beid/DemoWebApp/nginx.conf
+++ b/Beid/DemoWebApp/nginx.conf
@@ -5,8 +5,8 @@ http {
         listen 443 ssl;
         server_name eid.mintplayer.com;
 
-        ssl_certificate     /etc/nginx/certs/certificate.crt;
-        ssl_certificate_key /etc/nginx/certs/privatekey.key;
+        ssl_certificate     /etc/nginx/certs/certificate.pem;
+        ssl_certificate_key /etc/nginx/certs/privatekey.pem;
         ssl_protocols       TLSv1.2;
 
         # The whole reason this nginx exists: advertise ONLY PKCS#1 v1.5 in the


### PR DESCRIPTION
## Summary

- **Root cause:** Go's `crypto/tls` (used by Traefik) hardcodes `rsa_pss_rsae_sha256` first in the mTLS `CertificateRequest` `signature_algorithms`. Belgian eID cards can't sign RSA-PSS, so Firefox/NSS picks PSS, calls `C_Sign` on the card, and hangs until TCP timeout. Chrome works because Schannel→MSCAPI→eID-CSP is a different code path that filters PSS out. See `Beid/DemoWebApp/FIREFOX-MTLS-PSS-ROOTCAUSE.md` for the full diagnosis (verified live via `openssl s_client -trace`).
- **Fix:** Insert nginx (OpenSSL) as TLS terminator for `eid.mintplayer.com` only. Traefik does TCP TLS-passthrough on `HostSNI`. nginx pins `signature_algorithms` to PKCS#1 v1.5 only via `ssl_conf_command SignatureAlgorithms RSA+SHA256:RSA+SHA384:RSA+SHA512`. All other Traefik-fronted apps on the VPS are unchanged.
- **Cert sharing:** A phantom HTTP router on `nginx-eid` triggers Traefik's existing Let's Encrypt flow; `traefik-certs-dumper` (added separately on the VPS) extracts the cert from `acme.json` for nginx to read.
- **Docs:** New `Beid/DemoWebApp/Readme.md` covers the architecture, VPS one-time setup, bootstrap commands, and references the analysis docs.

## Test plan

- [ ] VPS: `docker compose ps certs-dumper` in `/var/www/traefik` shows `Up`
- [ ] VPS: `ls /var/www/traefik/dumped-certs/letsencrypt/eid.mintplayer.com/` shows `certificate.crt` + `privatekey.key`
- [ ] After merge: GitHub Action `Build, Publish & Deploy eID` completes successfully
- [ ] `openssl s_client -connect eid.mintplayer.com:443 -tls1_2 -trace` shows `signature_algorithms` starting with `rsa_pkcs1_sha256` (not `rsa_pss_rsae_sha256`)
- [ ] Chrome + eID card → `https://eid.mintplayer.com/todos` returns `PersonInfo` JSON (regression check)
- [ ] **Firefox + eID card → `https://eid.mintplayer.com/todos` returns `PersonInfo` JSON** (the actual fix)
- [ ] Firefox without eID inserted → 401 (not hang)
- [ ] Optional cleanup: remove unused `/var/www/traefik/dynamic/{tls.yml,belgium-root-ca4.pem,citizen-ca.pem}` once new stack is confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)