### PR TITLE
fix(valuecomparer): nullable obj param + null guard in generated AddHash (CS8765)

### DIFF
--- a/SourceGenerators/Cli/MintPlayer.CliGenerator.Attributes/MintPlayer.CliGenerator.Attributes.csproj
+++ b/SourceGenerators/Cli/MintPlayer.CliGenerator.Attributes/MintPlayer.CliGenerator.Attributes.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<LangVersion>14</LangVersion>
-		<Version>10.19.0</Version>
+		<Version>10.20.0</Version>
 		<Authors>Pieterjan De Clippel</Authors>
 		<Company>MintPlayer</Company>
 		<Description>Attributes for building CLI command trees with the MintPlayer source generator infrastructure</Description>

--- a/SourceGenerators/Cli/MintPlayer.CliGenerator/MintPlayer.CliGenerator.csproj
+++ b/SourceGenerators/Cli/MintPlayer.CliGenerator/MintPlayer.CliGenerator.csproj
@@ -12,7 +12,7 @@
 	</Target>
 
 	<PropertyGroup>
-		<Version>10.19.0</Version>
+		<Version>10.20.0</Version>
 		<Authors>Pieterjan De Clippel</Authors>
 		<Company>MintPlayer</Company>
 		<Description>System.CommandLine command tree source generator with dependency injection helpers</Description>

--- a/SourceGenerators/Mapper/MintPlayer.Mapper.Attributes/MintPlayer.Mapper.Attributes.csproj
+++ b/SourceGenerators/Mapper/MintPlayer.Mapper.Attributes/MintPlayer.Mapper.Attributes.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<LangVersion>14</LangVersion>
-		<Version>10.19.0</Version>
+		<Version>10.20.0</Version>
 		<Authors>Pieterjan De Clippel</Authors>
 		<Company>MintPlayer</Company>
 		<Description>This package contains attributes to automatically generate mappers</Description>

--- a/SourceGenerators/Mapper/MintPlayer.Mapper/MintPlayer.Mapper.csproj
+++ b/SourceGenerators/Mapper/MintPlayer.Mapper/MintPlayer.Mapper.csproj
@@ -11,7 +11,7 @@
 	</Target>
 
 	<PropertyGroup>
-		<Version>10.19.0</Version>
+		<Version>10.20.0</Version>
 		<Authors>Pieterjan De Clippel</Authors>
 		<Company>MintPlayer</Company>
 		<Description>This package automatically generates mappers for you</Description>

--- a/SourceGenerators/MintPlayer.SourceGenerators.Tools/MintPlayer.SourceGenerators.Tools.csproj
+++ b/SourceGenerators/MintPlayer.SourceGenerators.Tools/MintPlayer.SourceGenerators.Tools.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<Version>10.19.0</Version>
+		<Version>10.20.0</Version>
 		<Authors>Pieterjan De Clippel</Authors>
 		<Company>MintPlayer</Company>
 		<Description>This package contains useful tools for building source generators</Description>

--- a/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators.Attributes/MintPlayer.SourceGenerators.Attributes.csproj
+++ b/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators.Attributes/MintPlayer.SourceGenerators.Attributes.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<LangVersion>14</LangVersion>
-		<Version>10.19.0</Version>
+		<Version>10.20.0</Version>
 		<Authors>Pieterjan De Clippel</Authors>
 		<Company>MintPlayer</Company>
 		<Description>This package contains attributes for the source generators</Description>

--- a/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators/MintPlayer.SourceGenerators.csproj
+++ b/SourceGenerators/SourceGenerators/MintPlayer.SourceGenerators/MintPlayer.SourceGenerators.csproj
@@ -13,7 +13,7 @@
 	</Target>
 
 	<PropertyGroup>
-		<Version>10.19.0</Version>
+		<Version>10.20.0</Version>
 		<Authors>Pieterjan De Clippel</Authors>
 		<Company>MintPlayer</Company>
 		<Description>This package contains several source generators</Description>

--- a/SourceGenerators/ValueComparerGenerator/MintPlayer.ValueComparerGenerator.Attributes/MintPlayer.ValueComparerGenerator.Attributes.csproj
+++ b/SourceGenerators/ValueComparerGenerator/MintPlayer.ValueComparerGenerator.Attributes/MintPlayer.ValueComparerGenerator.Attributes.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<LangVersion>14</LangVersion>
-		<Version>10.19.0</Version>
+		<Version>10.20.0</Version>
 		<Authors>Pieterjan De Clippel</Authors>
 		<Company>MintPlayer</Company>
 		<Description>This package contains attributes for the ValueComparerGenerator</Description>

--- a/SourceGenerators/ValueComparerGenerator/MintPlayer.ValueComparerGenerator/Generators/ValueComparerGenerator.Producer.cs
+++ b/SourceGenerators/ValueComparerGenerator/MintPlayer.ValueComparerGenerator/Generators/ValueComparerGenerator.Producer.cs
@@ -1,4 +1,4 @@
-﻿using MintPlayer.SourceGenerators.Tools;
+using MintPlayer.SourceGenerators.Tools;
 using MintPlayer.ValueComparerGenerator.Models;
 using System.CodeDom.Compiler;
 
@@ -136,8 +136,11 @@ public sealed class TreeValueComparerProducer : Producer
                             }
                         }
 
-                        using (writer.OpenBlock($"protected override void AddHash(ref global::MintPlayer.SourceGenerators.Tools.Polyfills.HashCodeCompat h, {baseType.FullName} obj)"))
+                        using (writer.OpenBlock($"protected override void AddHash(ref global::MintPlayer.SourceGenerators.Tools.Polyfills.HashCodeCompat h, {baseType.FullName}? obj)"))
                         {
+                            // Base GetHashCode(T? obj) forwards a possibly-null obj here unguarded; match the
+                            // null sentinel used by the runtime comparer (HashCodeCompat null handling).
+                            writer.WriteLine("if (obj is null) { h.Add(0); return; }");
                             foreach (var prop in baseType.AllProperties)
                             {
                                 writer.WriteLine($"{comparerType}<{baseType.FullName}>.AddHash(ref h, obj.{prop.Name});");

--- a/SourceGenerators/ValueComparerGenerator/MintPlayer.ValueComparerGenerator/MintPlayer.ValueComparerGenerator.csproj
+++ b/SourceGenerators/ValueComparerGenerator/MintPlayer.ValueComparerGenerator/MintPlayer.ValueComparerGenerator.csproj
@@ -12,7 +12,7 @@
 	</Target>
 
 	<PropertyGroup>
-		<Version>10.19.0</Version>
+		<Version>10.20.0</Version>
 		<Authors>Pieterjan De Clippel</Authors>
 		<Company>MintPlayer</Company>
 		<Description>This package contains a source generator that generates value-comparers for you</Description>

--- a/SourceGenerators/ValueComparers/MintPlayer.ValueComparers.NewtonsoftJson/MintPlayer.ValueComparers.NewtonsoftJson.csproj
+++ b/SourceGenerators/ValueComparers/MintPlayer.ValueComparers.NewtonsoftJson/MintPlayer.ValueComparers.NewtonsoftJson.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<Version>10.19.0</Version>
+		<Version>10.20.0</Version>
 		<Authors>Pieterjan De Clippel</Authors>
 		<Company>MintPlayer</Company>
 		<Description>This package contains useful tools for building source generators</Description>


### PR DESCRIPTION
## What
The `ValueComparerGenerator` emitted its generated `AddHash` override with a **non-nullable** `obj` parameter, while the base `ValueComparer<T>.AddHash(ref HashCodeCompat h, T? obj)` declares it **nullable**. That mismatch raised **CS8765** ("nullability of parameter 'obj' doesn't match overridden member") in every consumer — e.g. 16 instances across MintPlayer.Spark's generated `TreeValueComparers.g.cs`.

## Change
`ValueComparerGenerator.Producer.cs` (the `AddHash` emit, ~line 139):
- Emit the parameter as `{type}? obj` to match the base signature → clears **CS8765**.
- Insert `if (obj is null) { h.Add(0); return; }` as the first body statement → prevents the **CS8602** that the nullable param would otherwise introduce, since `GetHashCode(T? obj)` forwards a possibly-null `obj` unguarded and the body dereferences `obj.{prop}`. The `h.Add(0)` sentinel matches the existing null convention in `ValueComparer.cs`.

The `AreEqual` emit is intentionally left unchanged (base `AreEqual(T x, T y)` is non-nullable, already correct).

## Verification
Built the `ValueComparerDebugging` consumer (`Nullable=enable`, which runs the generator as an analyzer). Generated comparers now emit e.g. `AddHash(ref ..., Vehicle? obj)` with the null guard and compile with **zero CS8765/CS8602** in generated code.

## Downstream follow-up
After this is published as a new package version (current consumers reference `10.19.0`), bump `MintPlayer.ValueComparerGenerator` (+ `.Attributes` / `.Tools` in lockstep) in MintPlayer.Spark's `MintPlayer.Spark.SourceGenerators.csproj`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)