### PR TITLE
fix(slnlaunch): sequential build phase before parallel launch (avoid MSBuild race)

### DIFF
--- a/SlnLaunch/MintPlayer.SlnLaunch.Tests/FakeOrchestrator.cs
+++ b/SlnLaunch/MintPlayer.SlnLaunch.Tests/FakeOrchestrator.cs
@@ -10,11 +10,27 @@ internal sealed class FakeOrchestrator : IProcessOrchestrator
     public bool WasCalled { get; private set; }
     public int Result { get; set; }
 
+    public bool BuildWasCalled { get; private set; }
+    public LaunchBuildOptions? BuildOptions { get; private set; }
+    public bool BuildResult { get; set; } = true;
+
+    /// <summary>True when <see cref="BuildAsync"/> had already run by the time <see cref="RunAsync"/> was called.</summary>
+    public bool BuildRanBeforeRun { get; private set; }
+
     public Task<int> RunAsync(LaunchPlan plan, LaunchRunOptions options, CancellationToken cancellationToken)
     {
+        BuildRanBeforeRun = BuildWasCalled;
         WasCalled = true;
         Plan = plan;
         Options = options;
         return Task.FromResult(Result);
+    }
+
+    public Task<bool> BuildAsync(LaunchPlan plan, LaunchBuildOptions options, CancellationToken cancellationToken)
+    {
+        BuildWasCalled = true;
+        BuildOptions = options;
+        Plan = plan;
+        return Task.FromResult(BuildResult);
     }
 }

--- a/SlnLaunch/MintPlayer.SlnLaunch.Tests/SlnLaunchCommandTests.cs
+++ b/SlnLaunch/MintPlayer.SlnLaunch.Tests/SlnLaunchCommandTests.cs
@@ -125,6 +125,84 @@ public class SlnLaunchCommandTests
     }
 
     [Fact]
+    public async Task Default_launch_builds_first_then_runs_with_no_build()
+    {
+        using var temp = new TempDirectory();
+        AddProject(temp, "HR/HR.csproj");
+        AddProject(temp, "Fleet/Fleet.csproj");
+        var path = temp.WriteFile("App.slnLaunch", TwoProjectsOneProfile);
+        var orchestrator = new FakeOrchestrator();
+        var command = Build(new FakeConsole(), orchestrator);
+        command.FilePath = path;
+
+        var code = await command.Execute(CancellationToken.None);
+
+        Assert.Equal(0, code);
+        Assert.True(orchestrator.BuildWasCalled);
+        Assert.True(orchestrator.WasCalled);
+        Assert.True(orchestrator.BuildRanBeforeRun);
+        Assert.All(orchestrator.Plan!.Commands, c => Assert.Contains("--no-build", c.Arguments));
+    }
+
+    [Fact]
+    public async Task Explicit_no_build_skips_build_phase_but_keeps_no_build_arg()
+    {
+        using var temp = new TempDirectory();
+        AddProject(temp, "HR/HR.csproj");
+        AddProject(temp, "Fleet/Fleet.csproj");
+        var path = temp.WriteFile("App.slnLaunch", TwoProjectsOneProfile);
+        var orchestrator = new FakeOrchestrator();
+        var command = Build(new FakeConsole(), orchestrator);
+        command.FilePath = path;
+        command.NoBuild = true;
+
+        var code = await command.Execute(CancellationToken.None);
+
+        Assert.Equal(0, code);
+        Assert.False(orchestrator.BuildWasCalled);
+        Assert.True(orchestrator.WasCalled);
+        Assert.All(orchestrator.Plan!.Commands, c => Assert.Contains("--no-build", c.Arguments));
+    }
+
+    [Fact]
+    public async Task Watch_skips_build_phase_and_does_not_pass_no_build()
+    {
+        using var temp = new TempDirectory();
+        AddProject(temp, "HR/HR.csproj");
+        AddProject(temp, "Fleet/Fleet.csproj");
+        var path = temp.WriteFile("App.slnLaunch", TwoProjectsOneProfile);
+        var orchestrator = new FakeOrchestrator();
+        var command = Build(new FakeConsole(), orchestrator);
+        command.FilePath = path;
+        command.Watch = true;
+
+        var code = await command.Execute(CancellationToken.None);
+
+        Assert.Equal(0, code);
+        Assert.False(orchestrator.BuildWasCalled);
+        Assert.True(orchestrator.WasCalled);
+        Assert.All(orchestrator.Plan!.Commands, c => Assert.DoesNotContain("--no-build", c.Arguments));
+    }
+
+    [Fact]
+    public async Task Build_failure_returns_one_and_does_not_launch()
+    {
+        using var temp = new TempDirectory();
+        AddProject(temp, "HR/HR.csproj");
+        AddProject(temp, "Fleet/Fleet.csproj");
+        var path = temp.WriteFile("App.slnLaunch", TwoProjectsOneProfile);
+        var orchestrator = new FakeOrchestrator { BuildResult = false };
+        var command = Build(new FakeConsole(), orchestrator);
+        command.FilePath = path;
+
+        var code = await command.Execute(CancellationToken.None);
+
+        Assert.Equal(1, code);
+        Assert.True(orchestrator.BuildWasCalled);
+        Assert.False(orchestrator.WasCalled);
+    }
+
+    [Fact]
     public async Task Forwards_pooled_arguments_per_project()
     {
         using var temp = new TempDirectory();

--- a/SlnLaunch/MintPlayer.SlnLaunch/Commands/SlnLaunchCommand.cs
+++ b/SlnLaunch/MintPlayer.SlnLaunch/Commands/SlnLaunchCommand.cs
@@ -74,6 +74,12 @@ public partial class SlnLaunchCommand : ICliCommand
         if (profile is null)
             return 1;
 
+        // Build once, sequentially, then run with --no-build — concurrent `dotnet run` builds race on the
+        // MSBuild server pipe and shared output DLLs. Skip the auto-build for --watch (it manages its own
+        // rebuilds) and for an explicit --no-build (the user builds themselves).
+        var autoBuild = !Watch && !NoBuild;
+        var effectiveNoBuild = NoBuild || autoBuild;
+
         LaunchPlan plan;
         try
         {
@@ -82,7 +88,7 @@ public partial class SlnLaunchCommand : ICliCommand
                 Watch = Watch,
                 Configuration = Configuration,
                 Framework = Framework,
-                NoBuild = NoBuild,
+                NoBuild = effectiveNoBuild,
                 Verbosity = Verbosity,
                 ForwardableArguments = _forwardable,
             };
@@ -105,7 +111,8 @@ public partial class SlnLaunchCommand : ICliCommand
 
         if (DryRun)
         {
-            _console.WriteInfo($"Profile '{plan.ProfileName}' would launch {plan.Commands.Count} project(s):");
+            var verb = autoBuild ? "would build then launch" : "would launch";
+            _console.WriteInfo($"Profile '{plan.ProfileName}' {verb} {plan.Commands.Count} project(s):");
             foreach (var command in plan.Commands)
                 _console.WriteLine($"  [{command.Label}] {command.ToDisplayString()}");
             return 0;
@@ -115,6 +122,13 @@ public partial class SlnLaunchCommand : ICliCommand
 
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         using var signals = new SignalScope(cts, _console);
+
+        if (autoBuild)
+        {
+            var buildOptions = new LaunchBuildOptions { Configuration = Configuration, Framework = Framework, Verbosity = Verbosity, NoPrefix = NoPrefix };
+            if (!await _orchestrator.BuildAsync(plan, buildOptions, cts.Token))
+                return cts.IsCancellationRequested ? 0 : 1;
+        }
 
         var runOptions = new LaunchRunOptions { NoPrefix = NoPrefix, KillOnFail = KillOnFail };
         return await _orchestrator.RunAsync(plan, runOptions, cts.Token);

--- a/SlnLaunch/MintPlayer.SlnLaunch/MintPlayer.SlnLaunch.csproj
+++ b/SlnLaunch/MintPlayer.SlnLaunch/MintPlayer.SlnLaunch.csproj
@@ -6,7 +6,7 @@
 		<LangVersion>14</LangVersion>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<Version>10.0.0</Version>
+		<Version>10.0.1</Version>
 		<PackageId>MintPlayer.SlnLaunch</PackageId>
 		<IsPackable>true</IsPackable>
 	</PropertyGroup>

--- a/SlnLaunch/MintPlayer.SlnLaunch/Services/IProcessOrchestrator.cs
+++ b/SlnLaunch/MintPlayer.SlnLaunch/Services/IProcessOrchestrator.cs
@@ -14,4 +14,11 @@ public interface IProcessOrchestrator
     /// code (or 1 if a process failed to start).
     /// </summary>
     Task<int> RunAsync(LaunchPlan plan, LaunchRunOptions options, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Builds every project in <paramref name="plan"/> sequentially (one <c>dotnet build</c> at a time) so the
+    /// parallel run can use <c>--no-build</c> and never races on the MSBuild server pipe or shared output DLLs.
+    /// Returns <c>true</c> when all builds succeed; <c>false</c> on the first failure or on cancellation.
+    /// </summary>
+    Task<bool> BuildAsync(LaunchPlan plan, LaunchBuildOptions options, CancellationToken cancellationToken);
 }

--- a/SlnLaunch/MintPlayer.SlnLaunch/Services/LaunchBuildOptions.cs
+++ b/SlnLaunch/MintPlayer.SlnLaunch/Services/LaunchBuildOptions.cs
@@ -1,0 +1,20 @@
+namespace MintPlayer.SlnLaunch.Services;
+
+/// <summary>
+/// Options for the sequential build phase that runs before the parallel launch. Mirrors the build-related
+/// knobs forwarded to each project so the up-front <c>dotnet build</c> matches the eventual <c>dotnet run</c>.
+/// </summary>
+public sealed class LaunchBuildOptions
+{
+    /// <summary>Build configuration (e.g. <c>Debug</c>/<c>Release</c>); <c>null</c> uses the SDK default.</summary>
+    public string? Configuration { get; init; }
+
+    /// <summary>Target framework to build; <c>null</c> builds the project's single/default framework.</summary>
+    public string? Framework { get; init; }
+
+    /// <summary>MSBuild verbosity for the build output; <c>null</c> uses the SDK default.</summary>
+    public string? Verbosity { get; init; }
+
+    /// <summary>Don't prefix build output with the project label.</summary>
+    public bool NoPrefix { get; init; }
+}

--- a/SlnLaunch/MintPlayer.SlnLaunch/Services/ProcessOrchestrator.cs
+++ b/SlnLaunch/MintPlayer.SlnLaunch/Services/ProcessOrchestrator.cs
@@ -82,33 +82,87 @@ internal sealed class ProcessOrchestrator : IProcessOrchestrator
 
     private Process StartProcess(LaunchCommand command, ConsoleColor color, bool noPrefix)
     {
-        var startInfo = new ProcessStartInfo
-        {
-            FileName = command.FileName,
-            WorkingDirectory = command.WorkingDirectory,
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-        };
-        foreach (var argument in command.Arguments)
-            startInfo.ArgumentList.Add(argument);
-
-        var process = new Process { StartInfo = startInfo, EnableRaisingEvents = true };
-        var prefix = noPrefix ? string.Empty : $"[{command.Label}] ";
-
-        process.OutputDataReceived += (_, e) =>
-        {
-            if (e.Data is not null) _console.WriteChildLine(prefix, e.Data, color, isError: false);
-        };
-        process.ErrorDataReceived += (_, e) =>
-        {
-            if (e.Data is not null) _console.WriteChildLine(prefix, e.Data, color, isError: true);
-        };
-
+        var process = CreateProcess(command.Label, command.WorkingDirectory, command.FileName, command.Arguments, color, noPrefix);
         process.Start();
         process.BeginOutputReadLine();
         process.BeginErrorReadLine();
         return process;
+    }
+
+    private Process CreateProcess(string label, string workingDirectory, string fileName, IReadOnlyList<string> arguments, ConsoleColor color, bool noPrefix)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = fileName,
+            WorkingDirectory = workingDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        foreach (var argument in arguments)
+            startInfo.ArgumentList.Add(argument);
+
+        var process = new Process { StartInfo = startInfo, EnableRaisingEvents = true };
+        var prefix = noPrefix ? string.Empty : $"[{label}] ";
+
+        process.OutputDataReceived += (_, e) => { if (e.Data is not null) _console.WriteChildLine(prefix, e.Data, color, isError: false); };
+        process.ErrorDataReceived += (_, e) => { if (e.Data is not null) _console.WriteChildLine(prefix, e.Data, color, isError: true); };
+        return process;
+    }
+
+    public async Task<bool> BuildAsync(LaunchPlan plan, LaunchBuildOptions options, CancellationToken cancellationToken)
+    {
+        if (plan.Commands.Count == 0)
+            return true;
+
+        _console.WriteInfo($"Building {plan.Commands.Count} project(s) before launch…");
+
+        for (var i = 0; i < plan.Commands.Count; i++)
+        {
+            var command = plan.Commands[i];
+            var color = _palette[i % _palette.Length];
+
+            var arguments = new List<string> { "build", command.ProjectPath };
+            if (!string.IsNullOrWhiteSpace(options.Configuration)) { arguments.Add("--configuration"); arguments.Add(options.Configuration!); }
+            if (!string.IsNullOrWhiteSpace(options.Framework)) { arguments.Add("--framework"); arguments.Add(options.Framework!); }
+            if (!string.IsNullOrWhiteSpace(options.Verbosity)) { arguments.Add("--verbosity"); arguments.Add(options.Verbosity!); }
+
+            int exitCode;
+            try
+            {
+                exitCode = await BuildOneAsync(command.Label, command.WorkingDirectory, arguments, color, options.NoPrefix, cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                return false; // cancelled — the caller maps this to a clean exit.
+            }
+
+            if (exitCode != 0)
+            {
+                _console.WriteError($"[{command.Label}] build failed (exit code {exitCode}). Not launching.");
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private async Task<int> BuildOneAsync(string label, string workingDirectory, IReadOnlyList<string> arguments, ConsoleColor color, bool noPrefix, CancellationToken cancellationToken)
+    {
+        using var process = CreateProcess(label, workingDirectory, "dotnet", arguments, color, noPrefix);
+        process.Start();
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+
+        try { await process.WaitForExitAsync(cancellationToken); }
+        catch (OperationCanceledException)
+        {
+            try { process.Kill(entireProcessTree: true); }
+            catch (Exception ex) when (ex is InvalidOperationException or Win32Exception) { }
+            throw;
+        }
+
+        return SafeExitCode(process);
     }
 
     /// <summary>


### PR DESCRIPTION
## Problem

`slnlaunch` launches every project in a profile via **concurrent** `dotnet run`. Each `dotnet run` triggers an implicit incremental build, so N projects = N concurrent builds, which race on:

- the **MSBuild Server named pipe** → `System.TimeoutException` → *"The build failed. Fix the build errors and run again."*
- **shared output DLLs** → `CS2012` / `MSB3027` / `MSB3021` *"file is locked by ..."*

Whichever project loses the race fails to build (nondeterministic — observed alternating between projects).

## Fix

Add a **sequential build phase** (one `dotnet build` at a time) before the parallel launch, and default the run phase to `--no-build`. A single build per project compiles each shared dependency exactly once → no concurrency → no race.

The auto-build is skipped when:
- `--watch` is passed (watch manages its own rebuilds), or
- `--no-build` is passed explicitly (the user builds themselves).

## Changes

- **`Services/LaunchBuildOptions.cs`** (new) — build-phase options mirroring the run-side build knobs.
- **`IProcessOrchestrator` / `ProcessOrchestrator`** — new `BuildAsync` (sequential, bails on first failure or cancellation) + `BuildOneAsync`; extracted shared process construction into `CreateProcess`.
- **`SlnLaunchCommand`** — `autoBuild = !Watch && !NoBuild`; runs the build phase before `RunAsync` and threads `--no-build` into the run plan; dry-run header reflects build-then-launch.
- **Tests** — `FakeOrchestrator.BuildAsync` + 4 new cases (default builds-then-runs-with-`--no-build`; explicit `--no-build` skips the build phase; `--watch` skips it and omits `--no-build`; build failure returns 1 and never launches).
- Tool version bumped to **10.0.1**.

## Verification

- `dotnet test` → **59/59 passing**.
- Packed 10.0.1 and ran `dnx MintPlayer.SlnLaunch` against the HR + Fleet profile: built both projects sequentially (no pipe `TimeoutException`, no DLL-lock errors), launched with `--no-build`, and both reached **HR `https://localhost:5005`** and **Fleet `https://localhost:5003`** with *Application started*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)