### PR TITLE
MintPlayer.Assertions: equivalency is unreachable from collection and dictionary subjects, and a zero-member expectation passes vacuously

### DIFF
--- a/Assertions/MintPlayer.Assertions.SourceGenerator.Tests/Diagnostics/ErasedEquivalencyAnalyzerTests.cs
+++ b/Assertions/MintPlayer.Assertions.SourceGenerator.Tests/Diagnostics/ErasedEquivalencyAnalyzerTests.cs
@@ -1,0 +1,176 @@
+namespace MintPlayer.Assertions.SourceGenerator.Tests.Diagnostics;
+
+/// <summary>
+/// MPA0004 — an equivalency call with both sides cast to <c>object</c>. The result stays correct,
+/// so this is a lost-guarantee hint: no generated accessors (reflection fallback instead) and no
+/// usable options lambda.
+/// </summary>
+public class ErasedEquivalencyAnalyzerTests
+{
+    private const string Analyzer = "ErasedEquivalencyAnalyzer";
+
+    private const string Poco = """
+        public class Poco
+        {
+            public int Value { get; set; }
+        }
+        """;
+
+    [Fact]
+    public async Task ItFlagsACallWithBothSidesErasedToObject()
+    {
+        var diagnostics = await Harness.Instance.RunAnalyzerAsync(Analyzer, $$"""
+            using MintPlayer.Assertions;
+
+            {{Poco}}
+
+            public class Test
+            {
+                public void Run()
+                {
+                    var actual = new Poco();
+                    var expected = new Poco();
+                    ((object)actual).Should().BeEquivalentTo((object)expected);
+                }
+            }
+            """);
+
+        diagnostics.Should().ContainSingle();
+        diagnostics[0].Id.Should().Be("MPA0004");
+    }
+
+    [Fact]
+    public async Task ItFlagsNotBeEquivalentToWithBothSidesErasedToObject()
+    {
+        var diagnostics = await Harness.Instance.RunAnalyzerAsync(Analyzer, $$"""
+            using MintPlayer.Assertions;
+
+            {{Poco}}
+
+            public class Test
+            {
+                public void Run()
+                {
+                    var actual = new Poco();
+                    var expected = new Poco { Value = 1 };
+                    ((object)actual).Should().NotBeEquivalentTo((object)expected);
+                }
+            }
+            """);
+
+        diagnostics.Should().ContainSingle();
+        diagnostics[0].Id.Should().Be("MPA0004");
+    }
+
+    [Fact]
+    public async Task ItIgnoresASubjectOnlyCastWithATypedExpectation()
+    {
+        // The form the repo's own tests and benchmarks use: the typed expectation still registers
+        // generated accessors, so nothing is lost.
+        var diagnostics = await Harness.Instance.RunAnalyzerAsync(Analyzer, $$"""
+            using MintPlayer.Assertions;
+
+            {{Poco}}
+
+            public class Test
+            {
+                public void Run()
+                {
+                    var actual = new Poco();
+                    var expected = new Poco();
+                    ((object)actual).Should().BeEquivalentTo(expected);
+                }
+            }
+            """);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItIgnoresAFullyTypedCall()
+    {
+        var diagnostics = await Harness.Instance.RunAnalyzerAsync(Analyzer, $$"""
+            using MintPlayer.Assertions;
+
+            {{Poco}}
+
+            public class Test
+            {
+                public void Run()
+                {
+                    var actual = new Poco();
+                    var expected = new Poco();
+                    actual.Should().BeEquivalentTo(expected);
+                }
+            }
+            """);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItIgnoresStringEquivalency()
+    {
+        // StringAssertions.BeEquivalentTo is a case-insensitive string compare, an entirely
+        // different method — flagging it would be a pure false positive.
+        var diagnostics = await Harness.Instance.RunAnalyzerAsync(Analyzer, """
+            using MintPlayer.Assertions;
+
+            public class Test
+            {
+                public void Run()
+                {
+                    "abc".Should().BeEquivalentTo("ABC");
+                    "abc".Should().NotBeEquivalentTo("def");
+                }
+            }
+            """);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ItIgnoresAnExpectationThatIsMerelyTypedObject()
+    {
+        // TExpectation infers to object here, from real typed values, with no cast written
+        // anywhere. Deliberately NOT flagged: variables and parameters that happen to be typed
+        // object are the legitimate case (generic helpers, extension authors forwarding a
+        // subject), so the analyzer keys on the explicit (object) cast instead of the inferred
+        // type argument. That trades a few missed erasures for zero noise.
+        var diagnostics = await Harness.Instance.RunAnalyzerAsync(Analyzer, $$"""
+            using MintPlayer.Assertions;
+
+            {{Poco}}
+
+            public class Test
+            {
+                public void Run()
+                {
+                    object actual = new Poco();
+                    object expected = new Poco();
+                    actual.Should().BeEquivalentTo(expected);
+                }
+
+                public void Forward<T>(T actual, T expected)
+                {
+                    actual.Should().BeEquivalentTo(expected);
+                }
+            }
+            """);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ItAdvertisesAWellFormedDescriptor()
+    {
+        var descriptors = Harness.Instance.DescriptorsOf(Analyzer);
+
+        descriptors.Should().ContainSingle();
+        descriptors[0].Id.Should().Be("MPA0004");
+        descriptors[0].DefaultSeverity.Should().Be(Microsoft.CodeAnalysis.DiagnosticSeverity.Info);
+        descriptors[0].IsEnabledByDefault.Should().BeTrue();
+        descriptors[0].Title.ToString().Should().NotBeEmpty();
+        descriptors[0].MessageFormat.ToString().Should().NotBeEmpty();
+    }
+}

--- a/Assertions/MintPlayer.Assertions.SourceGenerator/AnalyzerReleases.Unshipped.md
+++ b/Assertions/MintPlayer.Assertions.SourceGenerator/AnalyzerReleases.Unshipped.md
@@ -9,5 +9,6 @@ Rule ID  | Category              | Severity | Notes
 MPA0001  | MintPlayer.Assertions | Error    | Assertion returning a Task is not awaited
 MPA0002  | MintPlayer.Assertions | Warning  | Should() without an assertion does nothing
 MPA0003  | MintPlayer.Assertions | Warning  | AssertionScope is never disposed
+MPA0004  | MintPlayer.Assertions | Info     | Equivalency expectation erased to object loses generated accessors and options
 MPA0100  | MintPlayer.Assertions | Info     | FluentAssertions usage detected; migration fix available
 MPAG001  | MintPlayer.Assertions | Warning  | [GenerateAssertion] method has an unsupported shape

--- a/Assertions/MintPlayer.Assertions.SourceGenerator/Diagnostics/ErasedEquivalencyAnalyzer.Rule.cs
+++ b/Assertions/MintPlayer.Assertions.SourceGenerator/Diagnostics/ErasedEquivalencyAnalyzer.Rule.cs
@@ -1,0 +1,14 @@
+using Microsoft.CodeAnalysis;
+
+namespace MintPlayer.Assertions.Analyzers.Diagnostics;
+
+public static partial class DiagnosticRules
+{
+    public static readonly DiagnosticDescriptor ErasedEquivalencyRule = new DiagnosticDescriptor(
+        id: "MPA0004",
+        title: "Equivalency expectation is erased to object",
+        messageFormat: "An expectation cast to object falls back to reflection instead of the generated accessors, and cannot be configured with Excluding/Including. Pass the expectation as its concrete type.",
+        category: "MintPlayer.Assertions",
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: true);
+}

--- a/Assertions/MintPlayer.Assertions.SourceGenerator/Diagnostics/ErasedEquivalencyAnalyzer.cs
+++ b/Assertions/MintPlayer.Assertions.SourceGenerator/Diagnostics/ErasedEquivalencyAnalyzer.cs
@@ -1,0 +1,157 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System.Collections.Immutable;
+using System.Threading;
+
+namespace MintPlayer.Assertions.Analyzers.Diagnostics;
+
+/// <summary>
+/// MPA0004: an object-graph equivalency call whose subject <em>and</em> expectation are both
+/// deliberately cast to <see cref="object"/> — <c>((object)actual).Should().BeEquivalentTo((object)expected)</c>.
+/// </summary>
+/// <remarks>
+/// The comparison still produces the right answer: the engine recovers the runtime type. What is
+/// lost is silent. <c>EquivalencyScanner</c> excludes <see cref="object"/>, so no generated member
+/// accessors are registered for such a call site and the comparison walks the reflection fallback —
+/// the cost, and the trim/AOT safety, that the generated accessors exist to avoid. And with
+/// <c>TExpectation</c> bound to <see cref="object"/> the options lambda is unusable: there is no
+/// member to name in <c>Excluding(x => x.Prop)</c>.
+///
+/// Only <em>deliberate</em> erasure is reported, and only when both sides are erased. An expectation
+/// that merely happens to be typed <see cref="object"/> (a generic helper, an extension author
+/// forwarding a subject, a variable declared as <see cref="object"/>) is legitimate and stays quiet,
+/// as does the <c>Should((object)actual).BeEquivalentTo(expected)</c> form the repo's own tests and
+/// benchmarks use — a typed expectation still registers accessors.
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class ErasedEquivalencyAnalyzer : DiagnosticAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [DiagnosticRules.ErasedEquivalencyRule];
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+    }
+
+    private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+    {
+        var invocation = (InvocationExpressionSyntax)context.Node;
+
+        // Cheap syntactic pre-filter before touching the semantic model: the call has to be
+        // written as `<receiver>.BeEquivalentTo(...)`, and the receiver is where the erased
+        // subject would live.
+        if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
+            return;
+
+        if (memberAccess.Name.Identifier.ValueText is not ("BeEquivalentTo" or "NotBeEquivalentTo"))
+            return;
+
+        if (context.SemanticModel.GetSymbolInfo(invocation, context.CancellationToken).Symbol is not IMethodSymbol method)
+            return;
+
+        // StringAssertions.BeEquivalentTo is a different method entirely (case-insensitive string
+        // compare, non-generic) and must never be flagged — hence the containing-type check
+        // rather than a name check alone.
+        if (method.ContainingType?.Name != "EquivalencyAssertionExtensions"
+            || !SymbolHelpers.IsInAssertionsNamespace(method.ContainingType))
+            return;
+
+        var expectationIndex = IndexOfExpectationTypeParameter(method);
+        if (expectationIndex < 0 || method.TypeArguments.Length <= expectationIndex)
+            return;
+
+        if (method.TypeArguments[expectationIndex].SpecialType != SpecialType.System_Object)
+            return;
+
+        if (!IsErasedToObject(ExpectationArgument(method, invocation), context.SemanticModel, context.CancellationToken))
+            return;
+
+        if (!SubjectIsErasedToObject(memberAccess.Expression, context.SemanticModel, context.CancellationToken))
+            return;
+
+        context.ReportDiagnostic(Diagnostic.Create(DiagnosticRules.ErasedEquivalencyRule, invocation.GetLocation()));
+    }
+
+    /// <summary>
+    /// Position of the <c>TExpectation</c> type parameter. Located by name rather than assumed to
+    /// be first, because the collection overload is <c>BeEquivalentTo&lt;T, TExpectation&gt;</c>.
+    /// </summary>
+    private static int IndexOfExpectationTypeParameter(IMethodSymbol method)
+    {
+        var definition = method.OriginalDefinition;
+        for (var i = 0; i < definition.TypeParameters.Length; i++)
+        {
+            if (definition.TypeParameters[i].Name == "TExpectation")
+                return i;
+        }
+
+        return -1;
+    }
+
+    /// <summary>The syntax passed for the <c>expectation</c> parameter, named or positional.</summary>
+    private static ExpressionSyntax? ExpectationArgument(IMethodSymbol method, InvocationExpressionSyntax invocation)
+    {
+        var arguments = invocation.ArgumentList.Arguments;
+
+        foreach (var argument in arguments)
+        {
+            if (argument.NameColon?.Name.Identifier.ValueText == "expectation")
+                return argument.Expression;
+        }
+
+        // Positional: the reduced extension method drops the subject parameter, a static call does not.
+        var index = method.MethodKind == MethodKind.ReducedExtension ? 0 : 1;
+        return arguments.Count > index && arguments[index].NameColon is null ? arguments[index].Expression : null;
+    }
+
+    /// <summary>
+    /// True when the subject handed to <c>Should()</c> was deliberately cast to <see cref="object"/>.
+    /// </summary>
+    private static bool SubjectIsErasedToObject(ExpressionSyntax receiver, SemanticModel model, CancellationToken cancellationToken)
+    {
+        if (Unwrap(receiver) is not InvocationExpressionSyntax shouldInvocation)
+            return false;
+
+        var name = shouldInvocation.Expression switch
+        {
+            MemberAccessExpressionSyntax memberAccess => memberAccess.Name.Identifier.ValueText,
+            SimpleNameSyntax simpleName => simpleName.Identifier.ValueText,
+            _ => null,
+        };
+        if (name != "Should")
+            return false;
+
+        if (model.GetSymbolInfo(shouldInvocation, cancellationToken).Symbol is not IMethodSymbol should)
+            return false;
+
+        // `((object)x).Should()` — the subject is the member-access receiver.
+        if (should.MethodKind == MethodKind.ReducedExtension)
+        {
+            return shouldInvocation.Expression is MemberAccessExpressionSyntax memberAccess
+                && IsErasedToObject(memberAccess.Expression, model, cancellationToken);
+        }
+
+        // `Should((object)x)` — the subject is the first argument.
+        var arguments = shouldInvocation.ArgumentList.Arguments;
+        return arguments.Count > 0
+            && arguments[0].NameColon is null
+            && IsErasedToObject(arguments[0].Expression, model, cancellationToken);
+    }
+
+    /// <summary>True for an explicit <c>(object)</c> cast, parentheses ignored.</summary>
+    private static bool IsErasedToObject(ExpressionSyntax? expression, SemanticModel model, CancellationToken cancellationToken)
+        => Unwrap(expression) is CastExpressionSyntax cast
+            && model.GetTypeInfo(cast.Type, cancellationToken).Type?.SpecialType == SpecialType.System_Object;
+
+    private static ExpressionSyntax? Unwrap(ExpressionSyntax? expression)
+    {
+        while (expression is ParenthesizedExpressionSyntax parenthesized)
+            expression = parenthesized.Expression;
+
+        return expression;
+    }
+}

--- a/Assertions/MintPlayer.Assertions.SourceGenerator/MintPlayer.Assertions.SourceGenerator.csproj
+++ b/Assertions/MintPlayer.Assertions.SourceGenerator/MintPlayer.Assertions.SourceGenerator.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<!-- Ships inside the MintPlayer.Assertions package (analyzers/dotnet/cs); not packed standalone -->
 		<IsPackable>false</IsPackable>
-		<Version>1.0.1</Version>
+		<Version>1.1.0</Version>
 		<Authors>Pieterjan De Clippel</Authors>
 		<Company>MintPlayer</Company>
 		<Description>Compiler extensions for MintPlayer.Assertions: source generators (reflection-free equivalency member accessors, [GenerateAssertion] custom assertions) and analyzers with code fixes (un-awaited assertions, vacuous Should(), undisposed AssertionScope, FluentAssertions migration)</Description>

--- a/Assertions/MintPlayer.Assertions.Tests/CollectionAndDictionaryEquivalencyTests.cs
+++ b/Assertions/MintPlayer.Assertions.Tests/CollectionAndDictionaryEquivalencyTests.cs
@@ -1,0 +1,230 @@
+using MintPlayer.Assertions;
+
+namespace MintPlayer.Assertions.Tests;
+
+/// <summary>
+/// Covers the equivalency overloads reachable from a typed collection or dictionary subject:
+/// the collection <c>NotBeEquivalentTo</c> mirror, and both forms for dictionaries. Before these
+/// existed the only route was a cast to <c>object</c>, which loses the generated member accessors
+/// and makes the options lambda untypeable.
+/// </summary>
+public class CollectionAndDictionaryEquivalencyTests
+{
+    private sealed class Lane
+    {
+        public string Name { get; set; } = "";
+        public int Width { get; set; }
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Collections: the NotBeEquivalentTo mirror
+    // ---------------------------------------------------------------------------------------
+
+    [Fact]
+    public void NotBeEquivalentTo_Passes_ForCollectionsThatDiffer()
+    {
+        Lane[] subject = [new() { Name = "left", Width = 3 }];
+        Lane[] expectation = [new() { Name = "right", Width = 3 }];
+
+        subject.Should().NotBeEquivalentTo(expectation);
+    }
+
+    [Fact]
+    public void NotBeEquivalentTo_Fails_ForEquivalentCollections()
+    {
+        Lane[] subject = [new() { Name = "left", Width = 3 }];
+        Lane[] expectation = [new() { Name = "left", Width = 3 }];
+
+        var ex = Record.Exception(() => subject.Should().NotBeEquivalentTo(expectation));
+
+        Assert.IsType<AssertionFailedException>(ex);
+        Assert.Contains("no differences were found", ex!.Message);
+    }
+
+    [Fact]
+    public void NotBeEquivalentTo_Passes_ForCollectionsOfDifferentLength()
+    {
+        Lane[] subject = [new() { Name = "left", Width = 3 }, new() { Name = "right", Width = 4 }];
+        Lane[] expectation = [new() { Name = "left", Width = 3 }];
+
+        subject.Should().NotBeEquivalentTo(expectation);
+    }
+
+    /// <summary>Unordered matching is the default, so a reordered collection is still equivalent.</summary>
+    [Fact]
+    public void NotBeEquivalentTo_Fails_ForReorderedCollection_ByDefault()
+    {
+        Lane[] subject = [new() { Name = "left", Width = 3 }, new() { Name = "right", Width = 4 }];
+        Lane[] expectation = [new() { Name = "right", Width = 4 }, new() { Name = "left", Width = 3 }];
+
+        var ex = Record.Exception(() => subject.Should().NotBeEquivalentTo(expectation));
+
+        Assert.IsType<AssertionFailedException>(ex);
+    }
+
+    /// <summary>The typed options lambda is the whole point of having the overload — prove it binds.</summary>
+    [Fact]
+    public void NotBeEquivalentTo_HonoursTheTypedOptionsLambda()
+    {
+        Lane[] subject = [new() { Name = "left", Width = 3 }];
+        Lane[] expectation = [new() { Name = "left", Width = 99 }];
+
+        // Width is the only difference; excluding it makes the collections equivalent, so the
+        // negative assertion must fail.
+        var ex = Record.Exception(() => subject.Should().NotBeEquivalentTo(expectation,
+            o => o.ExcludingNested<Lane>(x => x.Width)));
+
+        Assert.IsType<AssertionFailedException>(ex);
+
+        // Without the exclusion the same pair differs, so it must pass.
+        subject.Should().NotBeEquivalentTo(expectation);
+    }
+
+    /// <summary>
+    /// Pins a sharp edge of the collection overloads: <c>Excluding</c> records a path relative to
+    /// the comparison root, and on a collection subject the root is the collection — so an element
+    /// member sits at <c>"[?].Width"</c> and a root-relative <c>"Width"</c> never matches. The
+    /// exclusion is silently ignored. Use <c>ExcludingNested&lt;T&gt;</c> (above) or a wildcard
+    /// path for element members. This only ever makes a comparison stricter than intended, so it
+    /// surfaces as a failing assertion rather than a silent pass.
+    /// </summary>
+    [Fact]
+    public void Excluding_IsRootRelative_AndSoDoesNotReachCollectionElementMembers()
+    {
+        Lane[] subject = [new() { Name = "left", Width = 3 }];
+        Lane[] expectation = [new() { Name = "left", Width = 99 }];
+
+        // The exclusion does not apply, so the collections still differ and the positive form fails.
+        var ex = Record.Exception(() => subject.Should().BeEquivalentTo(expectation, o => o.Excluding(x => x.Width)));
+        Assert.IsType<AssertionFailedException>(ex);
+
+        // A wildcard path does reach the element member.
+        subject.Should().BeEquivalentTo(expectation, o => o.ExcludingPath("*.Width"));
+    }
+
+    [Fact]
+    public void NotBeEquivalentTo_HonoursStrictOrdering()
+    {
+        Lane[] subject = [new() { Name = "left", Width = 3 }, new() { Name = "right", Width = 4 }];
+        Lane[] expectation = [new() { Name = "right", Width = 4 }, new() { Name = "left", Width = 3 }];
+
+        subject.Should().NotBeEquivalentTo(expectation, o => o.WithStrictOrdering());
+    }
+
+    [Fact]
+    public void NotBeEquivalentTo_WorksForListSubjects()
+    {
+        var subject = new List<Lane> { new() { Name = "left", Width = 3 } };
+        var expectation = new List<Lane> { new() { Name = "right", Width = 3 } };
+
+        subject.Should().NotBeEquivalentTo(expectation);
+    }
+
+    /// <summary>A collection compared against anonymous objects holding only the interesting members.</summary>
+    [Fact]
+    public void BeEquivalentTo_Passes_ForCollectionAgainstAnonymousSubset()
+    {
+        Lane[] subject = [new() { Name = "left", Width = 3 }];
+
+        subject.Should().BeEquivalentTo(new[] { new { Name = "left" } });
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Dictionaries
+    // ---------------------------------------------------------------------------------------
+
+    [Fact]
+    public void BeEquivalentTo_Passes_ForEquivalentDictionaries()
+    {
+        var subject = new Dictionary<string, Lane> { ["a"] = new() { Name = "left", Width = 3 } };
+        var expectation = new Dictionary<string, Lane> { ["a"] = new() { Name = "left", Width = 3 } };
+
+        subject.Should().BeEquivalentTo(expectation);
+    }
+
+    [Fact]
+    public void BeEquivalentTo_Fails_ForDifferingValue_AndNamesTheKey()
+    {
+        var subject = new Dictionary<string, Lane> { ["a"] = new() { Name = "left", Width = 3 } };
+        var expectation = new Dictionary<string, Lane> { ["a"] = new() { Name = "right", Width = 3 } };
+
+        var ex = Record.Exception(() => subject.Should().BeEquivalentTo(expectation));
+
+        Assert.IsType<AssertionFailedException>(ex);
+        Assert.Contains("[a]", ex!.Message);
+        Assert.Contains("\"right\"", ex.Message);
+        Assert.Contains("\"left\"", ex.Message);
+    }
+
+    [Fact]
+    public void BeEquivalentTo_Fails_ForMissingKey()
+    {
+        var subject = new Dictionary<string, int> { ["a"] = 1 };
+        var expectation = new Dictionary<string, int> { ["a"] = 1, ["b"] = 2 };
+
+        var ex = Record.Exception(() => subject.Should().BeEquivalentTo(expectation));
+
+        Assert.IsType<AssertionFailedException>(ex);
+        Assert.Contains("\"b\"", ex!.Message);
+    }
+
+    [Fact]
+    public void BeEquivalentTo_Fails_ForUnexpectedKey()
+    {
+        var subject = new Dictionary<string, int> { ["a"] = 1, ["b"] = 2 };
+        var expectation = new Dictionary<string, int> { ["a"] = 1 };
+
+        var ex = Record.Exception(() => subject.Should().BeEquivalentTo(expectation));
+
+        Assert.IsType<AssertionFailedException>(ex);
+        Assert.Contains("unexpected key", ex!.Message);
+    }
+
+    [Fact]
+    public void NotBeEquivalentTo_Passes_ForDictionariesThatDiffer()
+    {
+        var subject = new Dictionary<string, Lane> { ["a"] = new() { Name = "left", Width = 3 } };
+        var expectation = new Dictionary<string, Lane> { ["a"] = new() { Name = "right", Width = 3 } };
+
+        subject.Should().NotBeEquivalentTo(expectation);
+    }
+
+    [Fact]
+    public void NotBeEquivalentTo_Fails_ForEquivalentDictionaries()
+    {
+        var subject = new Dictionary<string, Lane> { ["a"] = new() { Name = "left", Width = 3 } };
+        var expectation = new Dictionary<string, Lane> { ["a"] = new() { Name = "left", Width = 3 } };
+
+        var ex = Record.Exception(() => subject.Should().NotBeEquivalentTo(expectation));
+
+        Assert.IsType<AssertionFailedException>(ex);
+        Assert.Contains("no differences were found", ex!.Message);
+    }
+
+    /// <summary>Dictionary values compared against anonymous objects holding a subset of members.</summary>
+    [Fact]
+    public void BeEquivalentTo_Passes_ForDictionaryValuesAgainstAnonymousSubset()
+    {
+        var subject = new Dictionary<string, Lane> { ["a"] = new() { Name = "left", Width = 3 } };
+
+        subject.Should().BeEquivalentTo(new Dictionary<string, object> { ["a"] = new { Name = "left" } });
+    }
+
+    [Fact]
+    public void BeEquivalentTo_HonoursTheTypedOptionsLambda_ForDictionaries()
+    {
+        var subject = new Dictionary<string, Lane> { ["a"] = new() { Name = "left", Width = 3 } };
+        var expectation = new Dictionary<string, Lane> { ["a"] = new() { Name = "left", Width = 99 } };
+
+        subject.Should().BeEquivalentTo(expectation, o => o.ExcludingNested<Lane>(x => x.Width));
+
+        var ex = Record.Exception(() => subject.Should().BeEquivalentTo(expectation));
+        Assert.IsType<AssertionFailedException>(ex);
+    }
+
+    [Fact]
+    public void BeEquivalentTo_Passes_ForTwoEmptyDictionaries()
+    {
+        new Dictionary<string, Lane>().Should().BeEquivalentTo(new Dictionary<string, Lane>());
+    }
+}

--- a/Assertions/MintPlayer.Assertions.Tests/CollectionAssertionsTests.cs
+++ b/Assertions/MintPlayer.Assertions.Tests/CollectionAssertionsTests.cs
@@ -415,6 +415,398 @@ public class CollectionAssertionsTests
     }
 
     [Fact]
+    public void NotHaveCount()
+    {
+        new[] { 1, 2 }.Should().NotHaveCount(3);
+
+        var ex = Fails(() => new[] { 1, 2 }.Should().NotHaveCount(2));
+        Assert.Contains("Did not expect", ex.Message);
+        Assert.Contains("to contain 2 item(s)", ex.Message);
+        Assert.Contains("but found {1, 2}", ex.Message);
+    }
+
+    [Fact]
+    public void NotHaveCount_NullSubject()
+    {
+        IEnumerable<int>? subject = null;
+        var ex = Fails(() => subject.Should().NotHaveCount(2));
+        Assert.Contains("not to contain 2 item(s)", ex.Message);
+        Assert.Contains("but found <null>", ex.Message);
+    }
+
+    [Fact]
+    public void NotContainSingle()
+    {
+        new[] { 1, 2 }.Should().NotContainSingle();
+        Array.Empty<int>().Should().NotContainSingle();
+
+        var ex = Fails(() => new[] { 1 }.Should().NotContainSingle());
+        Assert.Contains("Did not expect", ex.Message);
+        Assert.Contains("to contain a single item", ex.Message);
+        Assert.Contains("but found {1}", ex.Message);
+    }
+
+    [Fact]
+    public void NotContainSingle_NullSubject()
+    {
+        IEnumerable<int>? subject = null;
+        var ex = Fails(() => subject.Should().NotContainSingle());
+        Assert.Contains("not to contain a single item", ex.Message);
+        Assert.Contains("but found <null>", ex.Message);
+    }
+
+    [Fact]
+    public void NotContainSingle_Predicate()
+    {
+        // Two matches and zero matches both satisfy "not exactly one".
+        new[] { 1, 2, 3 }.Should().NotContainSingle(i => i > 1);
+        new[] { 1, 2, 3 }.Should().NotContainSingle(i => i > 5);
+
+        var ex = Fails(() => new[] { 1, 2, 3 }.Should().NotContainSingle(i => i == 2));
+        Assert.Contains("Did not expect", ex.Message);
+        Assert.Contains("to contain a single item matching the given predicate", ex.Message);
+        Assert.Contains("but found {2}", ex.Message);
+    }
+
+    [Fact]
+    public void NotContainInOrder()
+    {
+        new[] { 1, 2, 3 }.Should().NotContainInOrder(3, 1);  // present, but out of order
+        new[] { 1, 2, 3 }.Should().NotContainInOrder(1, 9);  // one item missing entirely
+
+        var ex = Fails(() => new[] { 1, 2, 3 }.Should().NotContainInOrder(1, 3));
+        Assert.Contains("Did not expect", ex.Message);
+        Assert.Contains("to contain {1, 3} in order", ex.Message);
+        Assert.Contains("but found {1, 2, 3}", ex.Message);
+    }
+
+    [Fact]
+    public void NotContainInOrder_EmptyExpectation_AlwaysFails()
+    {
+        // Every collection vacuously contains nothing in order, so the negation cannot hold.
+        var ex = Fails(() => new[] { 1 }.Should().NotContainInOrder());
+        Assert.Contains("to contain {empty} in order", ex.Message);
+    }
+
+    [Fact]
+    public void NotContainInOrder_NullSubject()
+    {
+        IEnumerable<int>? subject = null;
+        var ex = Fails(() => subject.Should().NotContainInOrder(1, 2));
+        Assert.Contains("not to contain {1, 2} in order", ex.Message);
+        Assert.Contains("but found <null>", ex.Message);
+    }
+
+    [Fact]
+    public void NotOnlyContain()
+    {
+        // 1 fails the predicate, so it is not true that the collection contains ONLY matches.
+        new[] { 1, 2, 3 }.Should().NotOnlyContain(i => i > 1);
+
+        var ex = Fails(() => new[] { 2, 3 }.Should().NotOnlyContain(i => i > 1));
+        Assert.Contains("Did not expect", ex.Message);
+        Assert.Contains("to only contain items matching the given predicate", ex.Message);
+        Assert.Contains("but all 2 item(s) did", ex.Message);
+    }
+
+    [Fact]
+    public void NotOnlyContain_EmptyCollection_Fails()
+    {
+        // OnlyContain holds vacuously for an empty collection, so its negation must fail.
+        var ex = Fails(() => Array.Empty<int>().Should().NotOnlyContain(i => i > 1));
+        Assert.Contains("but all 0 item(s) did", ex.Message);
+    }
+
+    [Fact]
+    public void NotOnlyContain_NullSubject()
+    {
+        IEnumerable<int>? subject = null;
+        var ex = Fails(() => subject.Should().NotOnlyContain(i => i > 1));
+        Assert.Contains("not to only contain items matching the given predicate", ex.Message);
+        Assert.Contains("but found <null>", ex.Message);
+    }
+
+    [Fact]
+    public void NotOnlyHaveUniqueItems()
+    {
+        new[] { 1, 2, 2 }.Should().NotOnlyHaveUniqueItems();
+
+        var ex = Fails(() => new[] { 1, 2, 3 }.Should().NotOnlyHaveUniqueItems());
+        Assert.Contains("Did not expect", ex.Message);
+        Assert.Contains("to only have unique items", ex.Message);
+        Assert.Contains("but found {1, 2, 3}", ex.Message);
+    }
+
+    [Fact]
+    public void NotOnlyHaveUniqueItems_EmptyCollection_Fails()
+    {
+        var ex = Fails(() => Array.Empty<int>().Should().NotOnlyHaveUniqueItems());
+        Assert.Contains("to only have unique items", ex.Message);
+    }
+
+    [Fact]
+    public void NotOnlyHaveUniqueItems_NullSubject()
+    {
+        IEnumerable<int>? subject = null;
+        var ex = Fails(() => subject.Should().NotOnlyHaveUniqueItems());
+        Assert.Contains("not to only have unique items", ex.Message);
+        Assert.Contains("but found <null>", ex.Message);
+    }
+
+    [Fact]
+    public void ContainNulls()
+    {
+        new string?[] { "a", null }.Should().ContainNulls();
+
+        var ex = Fails(() => new string?[] { "a", "b" }.Should().ContainNulls());
+        Assert.Contains("Expected", ex.Message);
+        Assert.Contains("to contain <null> items", ex.Message);
+        Assert.Contains("but found {\"a\", \"b\"}", ex.Message);
+    }
+
+    [Fact]
+    public void ContainNulls_NullSubject()
+    {
+        IEnumerable<string?>? subject = null;
+        var ex = Fails(() => subject.Should().ContainNulls());
+        Assert.Contains("to contain <null> items", ex.Message);
+        Assert.Contains("but found <null>", ex.Message);
+    }
+
+    [Fact]
+    public void NotStartWith_Item()
+    {
+        new[] { 1, 2 }.Should().NotStartWith(2);
+        Array.Empty<int>().Should().NotStartWith(1);  // an empty collection starts with nothing
+
+        var ex = Fails(() => new[] { 1, 2 }.Should().NotStartWith(1));
+        Assert.Contains("Did not expect", ex.Message);
+        Assert.Contains("to start with 1", ex.Message);
+    }
+
+    [Fact]
+    public void NotStartWith_Sequence()
+    {
+        new[] { 1, 2, 3 }.Should().NotStartWith(new[] { 2, 3 });
+        new[] { 1 }.Should().NotStartWith(new[] { 1, 2 });  // too short to have that prefix
+
+        var ex = Fails(() => new[] { 1, 2, 3 }.Should().NotStartWith(new[] { 1, 2 }));
+        Assert.Contains("Did not expect", ex.Message);
+        Assert.Contains("to start with {1, 2}", ex.Message);
+    }
+
+    [Fact]
+    public void NotStartWith_NullSubject()
+    {
+        IEnumerable<int>? subject = null;
+        var item = Fails(() => subject.Should().NotStartWith(1));
+        Assert.Contains("not to start with 1", item.Message);
+        Assert.Contains("but found <null>", item.Message);
+
+        var sequence = Fails(() => subject.Should().NotStartWith(new[] { 1, 2 }));
+        Assert.Contains("not to start with {1, 2}", sequence.Message);
+        Assert.Contains("but found <null>", sequence.Message);
+    }
+
+    [Fact]
+    public void NotEndWith_Item()
+    {
+        new[] { 1, 2 }.Should().NotEndWith(1);
+        Array.Empty<int>().Should().NotEndWith(1);
+
+        var ex = Fails(() => new[] { 1, 2 }.Should().NotEndWith(2));
+        Assert.Contains("Did not expect", ex.Message);
+        Assert.Contains("to end with 2", ex.Message);
+    }
+
+    [Fact]
+    public void NotEndWith_Sequence()
+    {
+        new[] { 1, 2, 3 }.Should().NotEndWith(new[] { 1, 2 });
+        new[] { 3 }.Should().NotEndWith(new[] { 2, 3 });  // too short to have that suffix
+
+        var ex = Fails(() => new[] { 1, 2, 3 }.Should().NotEndWith(new[] { 2, 3 }));
+        Assert.Contains("Did not expect", ex.Message);
+        Assert.Contains("to end with {2, 3}", ex.Message);
+    }
+
+    [Fact]
+    public void NotEndWith_NullSubject()
+    {
+        IEnumerable<int>? subject = null;
+        var item = Fails(() => subject.Should().NotEndWith(1));
+        Assert.Contains("not to end with 1", item.Message);
+        Assert.Contains("but found <null>", item.Message);
+
+        var sequence = Fails(() => subject.Should().NotEndWith(new[] { 1, 2 }));
+        Assert.Contains("not to end with {1, 2}", sequence.Message);
+        Assert.Contains("but found <null>", sequence.Message);
+    }
+
+    [Fact]
+    public void NotBeInAscendingOrder()
+    {
+        new[] { 2, 1, 3 }.Should().NotBeInAscendingOrder();
+
+        var ex = Fails(() => new[] { 1, 2, 3 }.Should().NotBeInAscendingOrder());
+        Assert.Contains("Did not expect", ex.Message);
+        Assert.Contains("to be in ascending order", ex.Message);
+        Assert.Contains("but found {1, 2, 3}", ex.Message);
+    }
+
+    [Fact]
+    public void NotBeInAscendingOrder_SingleItemCollection_Fails()
+    {
+        // One item is vacuously ordered, so the negation cannot hold.
+        var ex = Fails(() => new[] { 1 }.Should().NotBeInAscendingOrder());
+        Assert.Contains("to be in ascending order", ex.Message);
+    }
+
+    [Fact]
+    public void NotBeInAscendingOrder_Comparer()
+    {
+        // Reversed comparer: {1, 2} is NOT ascending under it, though it is under the default one.
+        var reversed = Comparer<int>.Create((a, b) => b.CompareTo(a));
+        new[] { 1, 2 }.Should().NotBeInAscendingOrder(reversed);
+
+        var ex = Fails(() => new[] { 2, 1 }.Should().NotBeInAscendingOrder(reversed));
+        Assert.Contains("to be in ascending order", ex.Message);
+    }
+
+    [Fact]
+    public void NotBeInAscendingOrder_Selector()
+    {
+        new[] { "bb", "a" }.Should().NotBeInAscendingOrder(s => s.Length);
+
+        var ex = Fails(() => new[] { "a", "bb" }.Should().NotBeInAscendingOrder(s => s.Length));
+        Assert.Contains("to be in ascending order", ex.Message);
+    }
+
+    [Fact]
+    public void NotBeInAscendingOrder_NullSubject()
+    {
+        IEnumerable<int>? subject = null;
+        var ex = Fails(() => subject.Should().NotBeInAscendingOrder());
+        Assert.Contains("not to be in ascending order", ex.Message);
+        Assert.Contains("but found <null>", ex.Message);
+    }
+
+    [Fact]
+    public void NotBeInDescendingOrder()
+    {
+        new[] { 1, 2, 3 }.Should().NotBeInDescendingOrder();
+
+        var ex = Fails(() => new[] { 3, 2, 1 }.Should().NotBeInDescendingOrder());
+        Assert.Contains("Did not expect", ex.Message);
+        Assert.Contains("to be in descending order", ex.Message);
+        Assert.Contains("but found {3, 2, 1}", ex.Message);
+    }
+
+    [Fact]
+    public void NotBeInDescendingOrder_Comparer()
+    {
+        var reversed = Comparer<int>.Create((a, b) => b.CompareTo(a));
+        new[] { 2, 1 }.Should().NotBeInDescendingOrder(reversed);
+
+        var ex = Fails(() => new[] { 1, 2 }.Should().NotBeInDescendingOrder(reversed));
+        Assert.Contains("to be in descending order", ex.Message);
+    }
+
+    [Fact]
+    public void NotBeInDescendingOrder_Selector()
+    {
+        new[] { "a", "bb" }.Should().NotBeInDescendingOrder(s => s.Length);
+
+        var ex = Fails(() => new[] { "bb", "a" }.Should().NotBeInDescendingOrder(s => s.Length));
+        Assert.Contains("to be in descending order", ex.Message);
+    }
+
+    [Fact]
+    public void NotBeInDescendingOrder_NullSubject()
+    {
+        IEnumerable<int>? subject = null;
+        var ex = Fails(() => subject.Should().NotBeInDescendingOrder());
+        Assert.Contains("not to be in descending order", ex.Message);
+        Assert.Contains("but found <null>", ex.Message);
+    }
+
+    [Fact]
+    public void AllEqualItems_AreBothAscendingAndDescending()
+    {
+        // Documented consequence: neither negation can hold for a run of equal items.
+        Assert.Contains("ascending", Fails(() => new[] { 1, 1 }.Should().NotBeInAscendingOrder()).Message);
+        Assert.Contains("descending", Fails(() => new[] { 1, 1 }.Should().NotBeInDescendingOrder()).Message);
+    }
+
+    [Fact]
+    public void NotAllBeOfType()
+    {
+        new object[] { "a", 1 }.Should().NotAllBeOfType<string>();
+
+        var ex = Fails(() => new object[] { "a", "b" }.Should().NotAllBeOfType<string>());
+        Assert.Contains("Did not expect", ex.Message);
+        Assert.Contains("to all be of type", ex.Message);
+        Assert.Contains("but all 2 item(s) are", ex.Message);
+    }
+
+    [Fact]
+    public void NotAllBeOfType_EmptyCollection_Fails()
+    {
+        var ex = Fails(() => Array.Empty<object>().Should().NotAllBeOfType<string>());
+        Assert.Contains("but all 0 item(s) are", ex.Message);
+    }
+
+    [Fact]
+    public void NotAllBeOfType_NullSubject()
+    {
+        IEnumerable<object>? subject = null;
+        var ex = Fails(() => subject.Should().NotAllBeOfType<string>());
+        Assert.Contains("not to all be of type", ex.Message);
+        Assert.Contains("but found <null>", ex.Message);
+    }
+
+    [Fact]
+    public void NotAllBeAssignableTo()
+    {
+        new object?[] { "a", null }.Should().NotAllBeAssignableTo<string>();
+
+        var ex = Fails(() => new object[] { "a", 1 }.Should().NotAllBeAssignableTo<IComparable>());
+        Assert.Contains("Did not expect", ex.Message);
+        Assert.Contains("to all be assignable to", ex.Message);
+        Assert.Contains("but all 2 item(s) are", ex.Message);
+    }
+
+    [Fact]
+    public void NotAllBeAssignableTo_NullSubject()
+    {
+        IEnumerable<object>? subject = null;
+        var ex = Fails(() => subject.Should().NotAllBeAssignableTo<string>());
+        Assert.Contains("not to all be assignable to", ex.Message);
+        Assert.Contains("but found <null>", ex.Message);
+    }
+
+    [Fact]
+    public void NegativeAssertions_EnumerateTheSubjectOnlyOnce()
+    {
+        var enumerations = 0;
+        IEnumerable<int> Sequence()
+        {
+            enumerations++;
+            yield return 1;
+            yield return 3;
+        }
+
+        Sequence().Should().NotHaveCount(3)
+            .And.NotStartWith(3)
+            .And.NotEndWith(1)
+            .And.NotContainInOrder(3, 1)
+            .And.NotContainSingle()
+            .And.NotOnlyContain(i => i == 1)
+            .And.NotBeInDescendingOrder();
+        Assert.Equal(1, enumerations);
+    }
+
+    [Fact]
     public void Subject_IsEnumeratedOnlyOnce_PerAssertionsInstance()
     {
         var enumerations = 0;

--- a/Assertions/MintPlayer.Assertions.Tests/ComparableAssertionsTests.cs
+++ b/Assertions/MintPlayer.Assertions.Tests/ComparableAssertionsTests.cs
@@ -115,5 +115,48 @@ public class ComparableAssertionsTests
     }
 
     [Fact]
+    public void NotBeInRange_Passes_WhenOutsideTheRange()
+    {
+        new Version(3, 0).Should().NotBeInRange(new Version(1, 0), new Version(2, 0));
+        new Version(0, 9).Should().NotBeInRange(new Version(1, 0), new Version(2, 0));
+    }
+
+    [Fact]
+    public void NotBeInRange_Fails_WhenInsideTheRange()
+    {
+        var version = new Version(1, 5);
+        var ex = Record.Exception(() => version.Should().NotBeInRange(new Version(1, 0), new Version(2, 0)));
+        Assert.IsType<AssertionFailedException>(ex);
+        Assert.Equal("Did not expect version to be between 1.0 and 2.0, but found 1.5.", ex.Message);
+    }
+
+    [Fact]
+    public void NotBeInRange_Fails_OnTheInclusiveBounds()
+    {
+        // BeInRange treats both ends as included, so the negative must reject them too.
+        var version = new Version(2, 0);
+        var ex = Record.Exception(() => version.Should().NotBeInRange(new Version(1, 0), new Version(2, 0)));
+        Assert.IsType<AssertionFailedException>(ex);
+        Assert.Equal("Did not expect version to be between 1.0 and 2.0, but found 2.0.", ex.Message);
+    }
+
+    [Fact]
+    public void NotBeInRange_Passes_WhenSubjectIsNull()
+    {
+        Version? version = null;
+        version.Should().NotBeInRange(new Version(1, 0), new Version(2, 0));
+    }
+
+    [Fact]
+    public void NotBeInRange_Works_ForAValueTypeSubject()
+    {
+        new Money(9m).Should().NotBeInRange(new Money(1m), new Money(5m));
+        var money = new Money(3m);
+        var ex = Record.Exception(() => money.Should().NotBeInRange(new Money(1m), new Money(5m)));
+        Assert.IsType<AssertionFailedException>(ex);
+        Assert.Equal("Did not expect money to be between 1 and 5, but found 3.", ex.Message);
+    }
+
+    [Fact]
     public void Chaining_Works() => new Version(1, 5).Should().BeGreaterThan(new Version(1, 0)).And.BeLessThan(new Version(2, 0));
 }

--- a/Assertions/MintPlayer.Assertions.Tests/DateOnlyAssertionsTests.cs
+++ b/Assertions/MintPlayer.Assertions.Tests/DateOnlyAssertionsTests.cs
@@ -136,4 +136,27 @@ public class DateOnlyAssertionsTests
         var ex = Fails(() => value.Should().BeOneOf(new DateOnly(2024, 3, 16), new DateOnly(2024, 3, 17)));
         Assert.Contains("to be one of", ex.Message);
     }
+
+    [Fact]
+    public void NotBeOneOf_Passes_And_Fails()
+    {
+        Sample.Should().NotBeOneOf(new DateOnly(2024, 3, 16), new DateOnly(2024, 3, 17));
+        var value = Sample;
+        var ex = Fails(() => value.Should().NotBeOneOf(new DateOnly(2024, 3, 14), Sample));
+        Assert.Equal("Did not expect value to be one of {2024-03-14, 2024-03-15}, but found 2024-03-15.", ex.Message);
+    }
+
+    [Fact]
+    public void NotBeOneOf_Passes_On_Null_Subject()
+    {
+        DateOnly? value = null;
+        value.Should().NotBeOneOf(Sample);
+    }
+
+    [Fact]
+    public void NotBeOneOf_Throws_On_Null_Values()
+    {
+        var value = Sample;
+        Assert.Throws<ArgumentNullException>(() => value.Should().NotBeOneOf((DateOnly[])null!, because: null));
+    }
 }

--- a/Assertions/MintPlayer.Assertions.Tests/DateTimeAssertionsTests.cs
+++ b/Assertions/MintPlayer.Assertions.Tests/DateTimeAssertionsTests.cs
@@ -208,4 +208,126 @@ public class DateTimeAssertionsTests
         var ex = Fails(() => value.Should().BeOneOf(Sample.AddDays(1), Sample.AddDays(2)));
         Assert.Contains("to be one of", ex.Message);
     }
+
+    [Fact]
+    public void NotBeOneOf_Passes_And_Fails()
+    {
+        Sample.Should().NotBeOneOf(Sample.AddDays(1), Sample.AddDays(2));
+        var value = Sample;
+        var ex = Fails(() => value.Should().NotBeOneOf(Sample.AddDays(-1), Sample));
+        Assert.Equal(
+            "Did not expect value to be one of {2024-03-14T10:30:45.0000000Z, 2024-03-15T10:30:45.0000000Z}, "
+            + "but found 2024-03-15T10:30:45.0000000Z.", ex.Message);
+    }
+
+    [Fact]
+    public void NotBeOneOf_Passes_On_Null_Subject()
+    {
+        DateTime? value = null;
+        value.Should().NotBeOneOf(Sample);
+    }
+
+    [Fact]
+    public void NotBeOneOf_Throws_On_Null_Values()
+    {
+        var value = Sample;
+        Assert.Throws<ArgumentNullException>(() => value.Should().NotBeOneOf((DateTime[])null!, because: null));
+    }
+
+    [Fact]
+    public void NotHaveYear_Passes_And_Fails()
+    {
+        Sample.Should().NotHaveYear(2023);
+        var value = Sample;
+        var ex = Fails(() => value.Should().NotHaveYear(2024));
+        Assert.Equal("Did not expect value to have year 2024.", ex.Message);
+    }
+
+    [Fact]
+    public void NotHaveMonth_Passes_And_Fails()
+    {
+        Sample.Should().NotHaveMonth(4);
+        var value = Sample;
+        var ex = Fails(() => value.Should().NotHaveMonth(3));
+        Assert.Equal("Did not expect value to have month 3.", ex.Message);
+    }
+
+    [Fact]
+    public void NotHaveDay_Passes_And_Fails()
+    {
+        Sample.Should().NotHaveDay(16);
+        var value = Sample;
+        var ex = Fails(() => value.Should().NotHaveDay(15));
+        Assert.Equal("Did not expect value to have day 15.", ex.Message);
+    }
+
+    [Fact]
+    public void NotHaveHour_Passes_And_Fails()
+    {
+        Sample.Should().NotHaveHour(11);
+        var value = Sample;
+        var ex = Fails(() => value.Should().NotHaveHour(10));
+        Assert.Equal("Did not expect value to have hour 10.", ex.Message);
+    }
+
+    [Fact]
+    public void NotHaveMinute_Passes_And_Fails()
+    {
+        Sample.Should().NotHaveMinute(31);
+        var value = Sample;
+        var ex = Fails(() => value.Should().NotHaveMinute(30));
+        Assert.Equal("Did not expect value to have minute 30.", ex.Message);
+    }
+
+    [Fact]
+    public void NotHaveSecond_Passes_And_Fails()
+    {
+        Sample.Should().NotHaveSecond(46);
+        var value = Sample;
+        var ex = Fails(() => value.Should().NotHaveSecond(45));
+        Assert.Equal("Did not expect value to have second 45.", ex.Message);
+    }
+
+    [Fact]
+    public void NotHave_Component_Family_Passes_On_Null_Subject()
+    {
+        DateTime? value = null;
+        value.Should().NotHaveYear(2024).And.NotHaveMonth(3).And.NotHaveDay(15)
+            .And.NotHaveHour(10).And.NotHaveMinute(30).And.NotHaveSecond(45);
+    }
+
+    [Fact]
+    public void NotBeSameDateAs_Passes_And_Fails()
+    {
+        Sample.Should().NotBeSameDateAs(Sample.AddDays(1));
+        // Same calendar day, different clock time: the time of day is ignored, so this must fail.
+        var value = Sample;
+        var ex = Fails(() => value.Should().NotBeSameDateAs(Sample.AddHours(2)));
+        Assert.Equal(
+            "Did not expect value to be on 2024-03-15T00:00:00.0000000Z, but found 2024-03-15T10:30:45.0000000Z.",
+            ex.Message);
+    }
+
+    [Fact]
+    public void NotBeSameDateAs_Passes_On_Null_Subject()
+    {
+        DateTime? value = null;
+        value.Should().NotBeSameDateAs(Sample);
+    }
+
+    [Fact]
+    public void NotBeIn_Passes_And_Fails()
+    {
+        Sample.Should().NotBeIn(DateTimeKind.Local);
+        var value = Sample;
+        var ex = Fails(() => value.Should().NotBeIn(DateTimeKind.Utc));
+        Assert.Equal("Did not expect value to be in DateTimeKind.Utc.", ex.Message);
+    }
+
+    [Fact]
+    public void NotBeIn_Passes_On_Null_Subject()
+    {
+        DateTime? value = null;
+        value.Should().NotBeIn(DateTimeKind.Utc);
+    }
 }

--- a/Assertions/MintPlayer.Assertions.Tests/DateTimeOffsetAssertionsTests.cs
+++ b/Assertions/MintPlayer.Assertions.Tests/DateTimeOffsetAssertionsTests.cs
@@ -206,4 +206,126 @@ public class DateTimeOffsetAssertionsTests
         var ex = Fails(() => value.Should().BeOneOf(Sample.AddDays(1), Sample.AddDays(2)));
         Assert.Contains("to be one of", ex.Message);
     }
+
+    [Fact]
+    public void NotBeOneOf_Passes_And_Fails()
+    {
+        Sample.Should().NotBeOneOf(Sample.AddDays(1), Sample.AddDays(2));
+        var value = Sample;
+        var ex = Fails(() => value.Should().NotBeOneOf(Sample.AddDays(-1), Sample));
+        Assert.Equal(
+            "Did not expect value to be one of {2024-03-14T10:30:45.0000000+02:00, 2024-03-15T10:30:45.0000000+02:00}, "
+            + "but found 2024-03-15T10:30:45.0000000+02:00.", ex.Message);
+    }
+
+    [Fact]
+    public void NotBeOneOf_Passes_On_Null_Subject()
+    {
+        DateTimeOffset? value = null;
+        value.Should().NotBeOneOf(Sample);
+    }
+
+    [Fact]
+    public void NotBeOneOf_Throws_On_Null_Values()
+    {
+        var value = Sample;
+        Assert.Throws<ArgumentNullException>(() => value.Should().NotBeOneOf((DateTimeOffset[])null!, because: null));
+    }
+
+    [Fact]
+    public void NotHaveYear_Passes_And_Fails()
+    {
+        Sample.Should().NotHaveYear(2023);
+        var value = Sample;
+        var ex = Fails(() => value.Should().NotHaveYear(2024));
+        Assert.Equal("Did not expect value to have year 2024.", ex.Message);
+    }
+
+    [Fact]
+    public void NotHaveMonth_Passes_And_Fails()
+    {
+        Sample.Should().NotHaveMonth(4);
+        var value = Sample;
+        var ex = Fails(() => value.Should().NotHaveMonth(3));
+        Assert.Equal("Did not expect value to have month 3.", ex.Message);
+    }
+
+    [Fact]
+    public void NotHaveDay_Passes_And_Fails()
+    {
+        Sample.Should().NotHaveDay(16);
+        var value = Sample;
+        var ex = Fails(() => value.Should().NotHaveDay(15));
+        Assert.Equal("Did not expect value to have day 15.", ex.Message);
+    }
+
+    [Fact]
+    public void NotHaveHour_Passes_And_Fails()
+    {
+        Sample.Should().NotHaveHour(11);
+        var value = Sample;
+        var ex = Fails(() => value.Should().NotHaveHour(10));
+        Assert.Equal("Did not expect value to have hour 10.", ex.Message);
+    }
+
+    [Fact]
+    public void NotHaveMinute_Passes_And_Fails()
+    {
+        Sample.Should().NotHaveMinute(31);
+        var value = Sample;
+        var ex = Fails(() => value.Should().NotHaveMinute(30));
+        Assert.Equal("Did not expect value to have minute 30.", ex.Message);
+    }
+
+    [Fact]
+    public void NotHaveSecond_Passes_And_Fails()
+    {
+        Sample.Should().NotHaveSecond(46);
+        var value = Sample;
+        var ex = Fails(() => value.Should().NotHaveSecond(45));
+        Assert.Equal("Did not expect value to have second 45.", ex.Message);
+    }
+
+    [Fact]
+    public void NotHave_Component_Family_Passes_On_Null_Subject()
+    {
+        DateTimeOffset? value = null;
+        value.Should().NotHaveYear(2024).And.NotHaveMonth(3).And.NotHaveDay(15)
+            .And.NotHaveHour(10).And.NotHaveMinute(30).And.NotHaveSecond(45);
+    }
+
+    [Fact]
+    public void NotHaveOffset_Passes_And_Fails()
+    {
+        Sample.Should().NotHaveOffset(TimeSpan.FromHours(3));
+        var value = Sample;
+        var ex = Fails(() => value.Should().NotHaveOffset(TimeSpan.FromHours(2)));
+        Assert.Equal("Did not expect value to have offset 02:00:00.", ex.Message);
+    }
+
+    [Fact]
+    public void NotHaveOffset_Passes_On_Null_Subject()
+    {
+        DateTimeOffset? value = null;
+        value.Should().NotHaveOffset(TimeSpan.FromHours(2));
+    }
+
+    [Fact]
+    public void NotBeSameDateAs_Passes_And_Fails()
+    {
+        Sample.Should().NotBeSameDateAs(Sample.AddDays(1));
+        // Same calendar day, different clock time: the time of day is ignored, so this must fail.
+        var value = Sample;
+        var ex = Fails(() => value.Should().NotBeSameDateAs(Sample.AddHours(2)));
+        Assert.Equal(
+            "Did not expect value to be on 2024-03-15T00:00:00.0000000, but found 2024-03-15T10:30:45.0000000+02:00.",
+            ex.Message);
+    }
+
+    [Fact]
+    public void NotBeSameDateAs_Passes_On_Null_Subject()
+    {
+        DateTimeOffset? value = null;
+        value.Should().NotBeSameDateAs(Sample);
+    }
 }

--- a/Assertions/MintPlayer.Assertions.Tests/DictionaryAssertionsTests.cs
+++ b/Assertions/MintPlayer.Assertions.Tests/DictionaryAssertionsTests.cs
@@ -142,6 +142,120 @@ public class DictionaryAssertionsTests
     }
 
     [Fact]
+    public void NotHaveCount()
+    {
+        Ages.Should().NotHaveCount(3);
+
+        var ex = Fails(() => Ages.Should().NotHaveCount(2));
+        Assert.Contains("Did not expect", ex.Message);
+        Assert.Contains("to contain 2 item(s)", ex.Message);
+    }
+
+    [Fact]
+    public void NotHaveCount_NullSubject()
+    {
+        Dictionary<string, int>? subject = null;
+        var ex = Fails(() => subject.Should().NotHaveCount(2));
+        Assert.Contains("not to contain 2 item(s)", ex.Message);
+        Assert.Contains("but found <null>", ex.Message);
+    }
+
+    [Fact]
+    public void NotContainKeys()
+    {
+        Ages.Should().NotContainKeys("carol", "dave");
+
+        // Holding even one of the keys is a failure — this is NotContainKey for each, not the
+        // strict logical negation of ContainKeys.
+        var ex = Fails(() => Ages.Should().NotContainKeys("carol", "alice"));
+        Assert.Contains("Did not expect", ex.Message);
+        Assert.Contains("to contain keys", ex.Message);
+        Assert.Contains("but found key(s) {\"alice\"}", ex.Message);
+    }
+
+    [Fact]
+    public void NotContainKeys_RespectsTheDictionarysOwnComparer()
+    {
+        var caseInsensitive = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["alice"] = 30,
+        };
+
+        // "ALICE" really is present under OrdinalIgnoreCase; using EqualityComparer<string>.Default
+        // instead would let this assertion pass and the test would fail here.
+        var ex = Fails(() => caseInsensitive.Should().NotContainKeys("ALICE"));
+        Assert.Contains("but found key(s) {\"ALICE\"}", ex.Message);
+
+        caseInsensitive.Should().NotContainKeys("carol");
+    }
+
+    [Fact]
+    public void NotContainKeys_NullSubject()
+    {
+        Dictionary<string, int>? subject = null;
+        var ex = Fails(() => subject.Should().NotContainKeys("alice"));
+        Assert.Contains("not to contain keys {\"alice\"}", ex.Message);
+        Assert.Contains("but found <null>", ex.Message);
+    }
+
+    [Fact]
+    public void NotContainValues()
+    {
+        Ages.Should().NotContainValues(99, 100);
+
+        var ex = Fails(() => Ages.Should().NotContainValues(99, 30));
+        Assert.Contains("Did not expect", ex.Message);
+        Assert.Contains("to contain values", ex.Message);
+        Assert.Contains("but found value(s) {30}", ex.Message);
+    }
+
+    [Fact]
+    public void NotContainValues_NullSubject()
+    {
+        Dictionary<string, int>? subject = null;
+        var ex = Fails(() => subject.Should().NotContainValues(30));
+        Assert.Contains("not to contain values {30}", ex.Message);
+        Assert.Contains("but found <null>", ex.Message);
+    }
+
+    [Fact]
+    public void NotContain_Pair()
+    {
+        Ages.Should().NotContain(new KeyValuePair<string, int>("alice", 31));  // wrong value
+        Ages.Should().NotContain(new KeyValuePair<string, int>("carol", 30));  // absent key
+
+        var ex = Fails(() => Ages.Should().NotContain(new KeyValuePair<string, int>("alice", 30)));
+        Assert.Contains("Did not expect", ex.Message);
+        Assert.Contains("30 at key \"alice\"", ex.Message);
+    }
+
+    [Fact]
+    public void NotContain_Pair_NullSubject()
+    {
+        Dictionary<string, int>? subject = null;
+        var ex = Fails(() => subject.Should().NotContain(new KeyValuePair<string, int>("alice", 30)));
+        Assert.Contains("not to contain 30 at key \"alice\"", ex.Message);
+        Assert.Contains("but found <null>", ex.Message);
+    }
+
+    [Fact]
+    public void NegativeAssertions_EnumerateThePairSequenceOnlyOnce()
+    {
+        var enumerations = 0;
+        IEnumerable<KeyValuePair<string, int>> Sequence()
+        {
+            enumerations++;
+            yield return new("x", 1);
+        }
+
+        Sequence().Should().NotHaveCount(2)
+            .And.NotContainKeys("y")
+            .And.NotContainValues(2)
+            .And.NotContain(new KeyValuePair<string, int>("x", 2));
+        Assert.Equal(1, enumerations);
+    }
+
+    [Fact]
     public void Should_PicksDictionaryAssertions_ForPairSequences()
     {
         // A plain sequence of pairs (not a dictionary) also binds to the dictionary assertions.

--- a/Assertions/MintPlayer.Assertions.Tests/EnumAssertionsTests.cs
+++ b/Assertions/MintPlayer.Assertions.Tests/EnumAssertionsTests.cs
@@ -117,5 +117,50 @@ public class EnumAssertionsTests
     }
 
     [Fact]
+    public void NotBeDefined_Passes_ForUndeclaredValue() => ((Color)42).Should().NotBeDefined();
+
+    [Fact]
+    public void NotBeDefined_Passes_WhenNull()
+    {
+        Color? value = null;
+        value.Should().NotBeDefined();
+    }
+
+    [Fact]
+    public void NotBeDefined_Fails_ForDeclaredMember()
+    {
+        var value = Color.Blue;
+        var ex = Record.Exception(() => value.Should().NotBeDefined());
+        Assert.IsType<AssertionFailedException>(ex);
+        Assert.Equal($"Did not expect value to be defined in {typeof(Color).FullName}, but found Color.Blue.", ex.Message);
+    }
+
+    [Fact]
+    public void NotBeOneOf_Passes_WhenNotContained() => Color.Blue.Should().NotBeOneOf(Color.Red, Color.Green);
+
+    [Fact]
+    public void NotBeOneOf_Passes_WhenNull()
+    {
+        Color? value = null;
+        value.Should().NotBeOneOf(Color.Red, Color.Green);
+    }
+
+    [Fact]
+    public void NotBeOneOf_Fails_WhenContained()
+    {
+        var value = Color.Green;
+        var ex = Record.Exception(() => value.Should().NotBeOneOf(Color.Red, Color.Green));
+        Assert.IsType<AssertionFailedException>(ex);
+        Assert.Equal("Did not expect value to be one of {Color.Red, Color.Green}, but found Color.Green.", ex.Message);
+    }
+
+    [Fact]
+    public void NotBeOneOf_Throws_WhenValuesAreNull()
+    {
+        var value = Color.Green;
+        Assert.Throws<ArgumentNullException>(() => value.Should().NotBeOneOf((IEnumerable<Color>)null!));
+    }
+
+    [Fact]
     public void Chaining_Works() => Access.ReadWrite.Should().HaveFlag(Access.Read).And.HaveFlag(Access.Write).And.BeDefined();
 }

--- a/Assertions/MintPlayer.Assertions.Tests/NumericAssertionsTests.cs
+++ b/Assertions/MintPlayer.Assertions.Tests/NumericAssertionsTests.cs
@@ -218,5 +218,95 @@ public class NumericAssertionsTests
     }
 
     [Fact]
+    public void NotBePositive_Passes_WhenZeroOrNegative()
+    {
+        0.Should().NotBePositive();
+        (-1).Should().NotBePositive();
+    }
+
+    [Fact]
+    public void NotBePositive_Passes_WhenNull()
+    {
+        int? value = null;
+        value.Should().NotBePositive();
+    }
+
+    [Fact]
+    public void NotBePositive_Passes_ForNaN() => double.NaN.Should().NotBePositive();
+
+    [Fact]
+    public void NotBePositive_Fails_WhenPositive()
+    {
+        var value = 1;
+        var ex = Record.Exception(() => value.Should().NotBePositive());
+        Assert.IsType<AssertionFailedException>(ex);
+        Assert.Equal("Did not expect value to be positive, but found 1.", ex.Message);
+    }
+
+    [Fact]
+    public void NotBeNegative_Passes_WhenZeroOrPositive()
+    {
+        0.Should().NotBeNegative();
+        1.Should().NotBeNegative();
+    }
+
+    [Fact]
+    public void NotBeNegative_Passes_WhenNull()
+    {
+        int? value = null;
+        value.Should().NotBeNegative();
+    }
+
+    [Fact]
+    public void NotBeNegative_Passes_ForNaN() => double.NaN.Should().NotBeNegative();
+
+    [Fact]
+    public void NotBeNegative_Fails_WhenNegative()
+    {
+        var value = -1;
+        var ex = Record.Exception(() => value.Should().NotBeNegative());
+        Assert.IsType<AssertionFailedException>(ex);
+        Assert.Equal("Did not expect value to be negative, but found -1.", ex.Message);
+    }
+
+    [Fact]
+    public void NotBeOneOf_Passes_WhenNotContained() => 42.Should().NotBeOneOf(1, 2, 3);
+
+    [Fact]
+    public void NotBeOneOf_Passes_WhenNull()
+    {
+        int? value = null;
+        value.Should().NotBeOneOf(1, 2, 3);
+    }
+
+    [Fact]
+    public void NotBeOneOf_Passes_ForAnEmptySet() => 42.Should().NotBeOneOf();
+
+    [Fact]
+    public void NotBeOneOf_Fails_WhenContained()
+    {
+        var value = 2;
+        var ex = Record.Exception(() => value.Should().NotBeOneOf(1, 2, 3));
+        Assert.IsType<AssertionFailedException>(ex);
+        Assert.Equal("Did not expect value to be one of {1, 2, 3}, but found 2.", ex.Message);
+    }
+
+    [Fact]
+    public void NotBeOneOf_Fails_WithReason_OnTheEnumerableOverload()
+    {
+        var value = 2;
+        var ex = Record.Exception(() => value.Should().NotBeOneOf(new[] { 1, 2 }, "{0} is reserved", 2));
+        Assert.IsType<AssertionFailedException>(ex);
+        Assert.Equal("Did not expect value to be one of {1, 2} because 2 is reserved, but found 2.", ex.Message);
+    }
+
+    [Fact]
+    public void NotBeOneOf_Throws_WhenValuesAreNull()
+    {
+        var value = 2;
+        Assert.Throws<ArgumentNullException>(() => value.Should().NotBeOneOf((IEnumerable<int>)null!));
+    }
+
+    [Fact]
     public void Chaining_Works() => 7.Should().BePositive().And.BeLessThan(10).And.BeOneOf(6, 7, 8);
 }

--- a/Assertions/MintPlayer.Assertions.Tests/ReadmeSamplesTests.cs
+++ b/Assertions/MintPlayer.Assertions.Tests/ReadmeSamplesTests.cs
@@ -176,4 +176,63 @@ public class DocSamples
     {
         typeof(Order).Should().BeAClass().And.NotBeDecoratedWith<ObsoleteAttribute>();
     }
+
+    [Fact]
+    public void DictionaryEquivalency()
+    {
+        var lanes = new Dictionary<string, Lane> { ["left"] = new() { Width = 3 } };
+
+        lanes.Should().BeEquivalentTo(new Dictionary<string, object>
+        {
+            ["left"] = new { Width = 3 },
+        });
+    }
+
+    /// <summary>
+    /// The README states that a comparison which compares nothing is refused, and quotes the
+    /// message. This keeps that promise honest.
+    /// </summary>
+    [Fact]
+    public void VacuousComparisonIsRefused()
+    {
+        var invoice = new Invoice { Name = "ACME", Amount = 2 };
+
+        var ex = Record.Exception(() => invoice.Should().BeEquivalentTo(new object()));
+
+        Assert.IsType<InvalidOperationException>(ex);
+        Assert.Contains("No members were compared", ex!.Message);
+        Assert.Contains("AllowingVacuousComparison()", ex.Message);
+
+        // And the documented opt-out works.
+        invoice.Should().BeEquivalentTo(new object(), o => o.AllowingVacuousComparison());
+    }
+
+    /// <summary>
+    /// The README warns that Excluding is root-relative and so does not reach a collection
+    /// element's member. Pin both halves of that claim.
+    /// </summary>
+    [Fact]
+    public void ExcludingIsRootRelativeOnCollections()
+    {
+        Lane[] subject = [new() { Width = 3 }];
+        Lane[] expectation = [new() { Width = 99 }];
+
+        subject.Should().BeEquivalentTo(expectation, o => o.ExcludingNested<Lane>(x => x.Width));
+        subject.Should().BeEquivalentTo(expectation, o => o.ExcludingPath("*.Width"));
+
+        var ex = Record.Exception(() => subject.Should().BeEquivalentTo(expectation, o => o.Excluding(x => x.Width)));
+        Assert.IsType<AssertionFailedException>(ex);
+    }
+}
+
+public class Lane
+{
+    public string Name { get; set; } = "";
+    public int Width { get; set; }
+}
+
+public class Invoice
+{
+    public string Name { get; set; } = "";
+    public int Amount { get; set; }
 }

--- a/Assertions/MintPlayer.Assertions.Tests/ReferenceTypeAndDelegateAssertionsTests.cs
+++ b/Assertions/MintPlayer.Assertions.Tests/ReferenceTypeAndDelegateAssertionsTests.cs
@@ -212,6 +212,42 @@ public class ReferenceTypeAssertionsTests
         value.Should().Match(v => v is null);
     }
 
+    [Fact]
+    public void NotMatch_PassesWhenThePredicateDoesNotHold()
+        => ((object)"hello").Should().NotMatch(v => v is string { Length: 3 });
+
+    [Fact]
+    public void NotMatch_FailsWhenThePredicateHolds()
+    {
+        var value = (object)"hello";
+
+        var ex = Record.Exception(() => value.Should().NotMatch(v => v is string { Length: 5 }));
+
+        Assert.IsType<AssertionFailedException>(ex);
+        Assert.Equal("Did not expect value to match the given predicate, but \"hello\" did.", ex.Message);
+    }
+
+    [Fact]
+    public void NotMatch_ReceivesNull_AndDoesNotPassItAutomatically()
+    {
+        object? value = null;
+
+        // Unlike the other negatives, a null subject is handed to the predicate rather than
+        // short-circuited to a pass — so a predicate that accepts null makes this fail.
+        var ex = Record.Exception(() => value.Should().NotMatch(v => v is null));
+
+        Assert.IsType<AssertionFailedException>(ex);
+        Assert.Equal("Did not expect value to match the given predicate, but <null> did.", ex.Message);
+    }
+
+    [Fact]
+    public void NotMatch_ThrowsWhenThePredicateIsNull()
+    {
+        var value = new object();
+
+        Assert.Throws<ArgumentNullException>(() => value.Should().NotMatch(null!));
+    }
+
     #endregion
 
     #region Chaining

--- a/Assertions/MintPlayer.Assertions.Tests/StringAssertionsTests.cs
+++ b/Assertions/MintPlayer.Assertions.Tests/StringAssertionsTests.cs
@@ -343,6 +343,169 @@ public class StringAssertionsTests
     }
 
     [Fact]
+    public void NotHaveLength_Passes_And_Fails()
+    {
+        "hello".Should().NotHaveLength(4);
+        var value = "hello";
+        var ex = Fails(() => value.Should().NotHaveLength(5));
+        Assert.Equal("Did not expect value to have length 5.", ex.Message);
+    }
+
+    [Fact]
+    public void NotHaveLength_Passes_On_Null()
+    {
+        string? value = null;
+        value.Should().NotHaveLength(0);
+    }
+
+    [Fact]
+    public void NotStartWithEquivalentOf_Passes_And_Fails()
+    {
+        "hello world".Should().NotStartWithEquivalentOf("world");
+        // The positive form ignores casing, so the negative must too: "hello" still matches "Hello".
+        var value = "Hello world";
+        var ex = Fails(() => value.Should().NotStartWithEquivalentOf("hello"));
+        Assert.Equal("Did not expect value to start with the equivalent of \"hello\".", ex.Message);
+    }
+
+    [Fact]
+    public void NotStartWithEquivalentOf_Passes_On_Null_And_Rejects_A_Null_Argument()
+    {
+        string? value = null;
+        value.Should().NotStartWithEquivalentOf("hello");
+        var other = "hello";
+        Assert.Throws<ArgumentNullException>(() => other.Should().NotStartWithEquivalentOf(null!));
+    }
+
+    [Fact]
+    public void NotEndWithEquivalentOf_Passes_And_Fails()
+    {
+        "hello world".Should().NotEndWithEquivalentOf("hello");
+        var value = "hello World";
+        var ex = Fails(() => value.Should().NotEndWithEquivalentOf("world"));
+        Assert.Equal("Did not expect value to end with the equivalent of \"world\".", ex.Message);
+    }
+
+    [Fact]
+    public void NotEndWithEquivalentOf_Passes_On_Null_And_Rejects_A_Null_Argument()
+    {
+        string? value = null;
+        value.Should().NotEndWithEquivalentOf("world");
+        var other = "hello";
+        Assert.Throws<ArgumentNullException>(() => other.Should().NotEndWithEquivalentOf(null!));
+    }
+
+    [Fact]
+    public void NotMatchEquivalentOf_Passes_And_Fails()
+    {
+        "hello world".Should().NotMatchEquivalentOf("goodbye*");
+        // Casing is ignored by MatchEquivalentOf, so "hello*" still matches "Hello World".
+        var value = "Hello World";
+        var ex = Fails(() => value.Should().NotMatchEquivalentOf("hello*"));
+        Assert.Equal("Did not expect value to match the equivalent of \"hello*\", but found \"Hello World\".", ex.Message);
+    }
+
+    [Fact]
+    public void NotMatchEquivalentOf_Passes_On_Null()
+    {
+        string? value = null;
+        value.Should().NotMatchEquivalentOf("*");
+    }
+
+    [Fact]
+    public void NotContainAll_Passes_When_One_Is_Missing()
+        => "hello world".Should().NotContainAll("hello", "moon");
+
+    [Fact]
+    public void NotContainAll_Fails_When_Every_Value_Is_Present()
+    {
+        var value = "hello world";
+        var ex = Fails(() => value.Should().NotContainAll("hello", "world"));
+        Assert.Equal(
+            "Did not expect value to contain all of {\"hello\", \"world\"}, but found every one of them in \"hello world\".",
+            ex.Message);
+    }
+
+    [Fact]
+    public void NotContainAll_Passes_On_Null_Subject()
+    {
+        string? value = null;
+        value.Should().NotContainAll("hello");
+    }
+
+    [Fact]
+    public void NotContainAny_Passes_When_None_Are_Present()
+        => "hello world".Should().NotContainAny("moon", "sun");
+
+    [Fact]
+    public void NotContainAny_Fails_And_Lists_Only_The_Offenders()
+    {
+        var value = "hello world";
+        var ex = Fails(() => value.Should().NotContainAny("moon", "world"));
+        Assert.Equal(
+            "Did not expect value to contain any of {\"moon\", \"world\"}, but found {\"world\"} in \"hello world\".",
+            ex.Message);
+    }
+
+    [Fact]
+    public void NotContainAny_Passes_On_Null_Subject_And_On_An_Empty_Set()
+    {
+        string? value = null;
+        value.Should().NotContainAny("hello");
+        "hello".Should().NotContainAny();
+    }
+
+    [Fact]
+    public void NotBeUpperCased_Passes_And_Fails()
+    {
+        "Hello".Should().NotBeUpperCased();
+        var value = "HELLO";
+        var ex = Fails(() => value.Should().NotBeUpperCased());
+        Assert.Equal("Did not expect value to be upper-cased, but found \"HELLO\".", ex.Message);
+    }
+
+    [Fact]
+    public void NotBeUpperCased_Fails_For_A_String_Without_Letters()
+    {
+        // BeUpperCased calls "42" upper-cased, so its negation must reject "42" rather than
+        // quietly pass on "there are no upper-case letters here".
+        var value = "42";
+        var ex = Fails(() => value.Should().NotBeUpperCased());
+        Assert.Equal("Did not expect value to be upper-cased, but found \"42\".", ex.Message);
+    }
+
+    [Fact]
+    public void NotBeUpperCased_Passes_On_Null()
+    {
+        string? value = null;
+        value.Should().NotBeUpperCased();
+    }
+
+    [Fact]
+    public void NotBeLowerCased_Passes_And_Fails()
+    {
+        "hellO".Should().NotBeLowerCased();
+        var value = "hello";
+        var ex = Fails(() => value.Should().NotBeLowerCased());
+        Assert.Equal("Did not expect value to be lower-cased, but found \"hello\".", ex.Message);
+    }
+
+    [Fact]
+    public void NotBeLowerCased_Fails_For_A_String_Without_Letters()
+    {
+        var value = "42";
+        var ex = Fails(() => value.Should().NotBeLowerCased());
+        Assert.Equal("Did not expect value to be lower-cased, but found \"42\".", ex.Message);
+    }
+
+    [Fact]
+    public void NotBeLowerCased_Passes_On_Null()
+    {
+        string? value = null;
+        value.Should().NotBeLowerCased();
+    }
+
+    [Fact]
     public void Chaining_With_And_Works()
     {
         "hello world".Should().StartWith("hello").And.EndWith("world").And.HaveLength(11);

--- a/Assertions/MintPlayer.Assertions.Tests/TimeOnlyAssertionsTests.cs
+++ b/Assertions/MintPlayer.Assertions.Tests/TimeOnlyAssertionsTests.cs
@@ -152,4 +152,37 @@ public class TimeOnlyAssertionsTests
         var ex = Fails(() => some.Should().NotHaveValue());
         Assert.Contains("Did not expect some to have a value", ex.Message);
     }
+
+    [Fact]
+    public void NotBeCloseTo_Passes_And_Fails()
+    {
+        Sample.Should().NotBeCloseTo(Sample.AddHours(3), TimeSpan.FromMinutes(1));
+        var value = Sample;
+        var ex = Fails(() => value.Should().NotBeCloseTo(Sample.AddMinutes(1), TimeSpan.FromMinutes(2)));
+        Assert.Equal("Did not expect value to be within 00:02:00 of 10:31:45.5000000, but found 10:30:45.5000000.", ex.Message);
+    }
+
+    [Fact]
+    public void NotBeCloseTo_Measures_Around_Midnight_Like_BeCloseTo()
+    {
+        // 00:01 is two minutes from 23:59 the short way round. A negative that naively subtracted
+        // would see 23h58m and wrongly pass, so this must fail.
+        var value = new TimeOnly(23, 59);
+        var ex = Fails(() => value.Should().NotBeCloseTo(new TimeOnly(0, 1), TimeSpan.FromMinutes(5)));
+        Assert.Equal("Did not expect value to be within 00:05:00 of 00:01:00.0000000, but found 23:59:00.0000000.", ex.Message);
+    }
+
+    [Fact]
+    public void NotBeCloseTo_Passes_On_Null_Subject()
+    {
+        TimeOnly? value = null;
+        value.Should().NotBeCloseTo(Sample, TimeSpan.FromMinutes(1));
+    }
+
+    [Fact]
+    public void NotBeCloseTo_Rejects_Negative_Precision()
+    {
+        var value = Sample;
+        Assert.Throws<ArgumentOutOfRangeException>(() => value.Should().NotBeCloseTo(Sample, TimeSpan.FromMinutes(-1)));
+    }
 }

--- a/Assertions/MintPlayer.Assertions.Tests/TimeSpanAssertionsTests.cs
+++ b/Assertions/MintPlayer.Assertions.Tests/TimeSpanAssertionsTests.cs
@@ -133,4 +133,61 @@ public class TimeSpanAssertionsTests
         var ex = Fails(() => some.Should().NotHaveValue());
         Assert.Contains("Did not expect some to have a value", ex.Message);
     }
+
+    [Fact]
+    public void NotBePositive_Passes_And_Fails()
+    {
+        TimeSpan.Zero.Should().NotBePositive();
+        (-Sample).Should().NotBePositive();
+        var value = Sample;
+        var ex = Fails(() => value.Should().NotBePositive());
+        Assert.Equal("Did not expect value to be positive, but found 01:30:00.", ex.Message);
+    }
+
+    [Fact]
+    public void NotBePositive_Passes_On_Null_Subject()
+    {
+        TimeSpan? value = null;
+        value.Should().NotBePositive();
+    }
+
+    [Fact]
+    public void NotBeNegative_Passes_And_Fails()
+    {
+        TimeSpan.Zero.Should().NotBeNegative();
+        Sample.Should().NotBeNegative();
+        var value = -Sample;
+        var ex = Fails(() => value.Should().NotBeNegative());
+        Assert.Equal("Did not expect value to be negative, but found -01:30:00.", ex.Message);
+    }
+
+    [Fact]
+    public void NotBeNegative_Passes_On_Null_Subject()
+    {
+        TimeSpan? value = null;
+        value.Should().NotBeNegative();
+    }
+
+    [Fact]
+    public void NotBeCloseTo_Passes_And_Fails()
+    {
+        Sample.Should().NotBeCloseTo(Sample + TimeSpan.FromMinutes(10), TimeSpan.FromMinutes(1));
+        var value = Sample;
+        var ex = Fails(() => value.Should().NotBeCloseTo(Sample + TimeSpan.FromSeconds(30), TimeSpan.FromMinutes(1)));
+        Assert.Equal("Did not expect value to be within 00:01:00 of 01:30:30, but found 01:30:00.", ex.Message);
+    }
+
+    [Fact]
+    public void NotBeCloseTo_Passes_On_Null_Subject()
+    {
+        TimeSpan? value = null;
+        value.Should().NotBeCloseTo(Sample, TimeSpan.FromMinutes(1));
+    }
+
+    [Fact]
+    public void NotBeCloseTo_Rejects_Negative_Precision()
+    {
+        var value = Sample;
+        Assert.Throws<ArgumentOutOfRangeException>(() => value.Should().NotBeCloseTo(Sample, TimeSpan.FromMinutes(-1)));
+    }
 }

--- a/Assertions/MintPlayer.Assertions.Tests/TypeAssertionsTests.cs
+++ b/Assertions/MintPlayer.Assertions.Tests/TypeAssertionsTests.cs
@@ -199,5 +199,131 @@ public class TypeAssertionsTests
     }
 
     [Fact]
+    public void NotBeDerivedFrom_Passes_WhenUnrelated() => typeof(Animal).Should().NotBeDerivedFrom<Dog>();
+
+    [Fact]
+    public void NotBeDerivedFrom_Passes_ForTheTypeItself() => typeof(Dog).Should().NotBeDerivedFrom<Dog>();
+
+    [Fact]
+    public void NotBeDerivedFrom_Fails_WhenDerived()
+    {
+        var type = typeof(Dog);
+        var ex = Record.Exception(() => type.Should().NotBeDerivedFrom<Animal>());
+        Assert.IsType<AssertionFailedException>(ex);
+        Assert.Equal($"Did not expect type to be derived from {typeof(Animal).FullName}.", ex.Message);
+    }
+
+    [Fact]
+    public void NotBeDerivedFrom_Passes_ForNullSubject()
+    {
+        Type? type = null;
+        type.Should().NotBeDerivedFrom<Animal>();
+    }
+
+    [Fact]
+    public void NotImplement_Passes_WhenTheInterfaceIsAbsent() => typeof(string).Should().NotImplement<IAnimal>();
+
+    [Fact]
+    public void NotImplement_Passes_ForTheInterfaceItself() => typeof(IAnimal).Should().NotImplement<IAnimal>();
+
+    [Fact]
+    public void NotImplement_Fails_WhenImplemented()
+    {
+        var type = typeof(Dog);
+        var ex = Record.Exception(() => type.Should().NotImplement<IAnimal>());
+        Assert.IsType<AssertionFailedException>(ex);
+        Assert.Equal($"Did not expect type to implement {typeof(IAnimal).FullName}.", ex.Message);
+    }
+
+    [Fact]
+    public void NotImplement_Throws_WhenTypeArgumentIsNotAnInterface()
+        => Assert.Throws<ArgumentException>(() => typeof(Dog).Should().NotImplement<Animal>());
+
+    [Fact]
+    public void NotImplement_Passes_ForNullSubject()
+    {
+        Type? type = null;
+        type.Should().NotImplement<IAnimal>();
+    }
+
+    [Fact]
+    public void NotBeAbstract_Passes_ForASealedClass() => typeof(Dog).Should().NotBeAbstract();
+
+    [Fact]
+    public void NotBeAbstract_Passes_ForAStaticClass() => typeof(Helpers).Should().NotBeAbstract();
+
+    [Fact]
+    public void NotBeAbstract_Fails_ForAnAbstractClass()
+    {
+        var type = typeof(Animal);
+        var ex = Record.Exception(() => type.Should().NotBeAbstract());
+        Assert.IsType<AssertionFailedException>(ex);
+        Assert.Equal("Did not expect type to be abstract.", ex.Message);
+    }
+
+    [Fact]
+    public void NotBeSealed_Passes_ForAnAbstractClass() => typeof(Animal).Should().NotBeSealed();
+
+    [Fact]
+    public void NotBeSealed_Passes_ForAStaticClass() => typeof(Helpers).Should().NotBeSealed();
+
+    [Fact]
+    public void NotBeSealed_Fails_ForASealedClass()
+    {
+        var type = typeof(Dog);
+        var ex = Record.Exception(() => type.Should().NotBeSealed());
+        Assert.IsType<AssertionFailedException>(ex);
+        Assert.Equal("Did not expect type to be sealed.", ex.Message);
+    }
+
+    [Fact]
+    public void NotBeStatic_Passes_ForANonStaticClass() => typeof(Dog).Should().NotBeStatic();
+
+    [Fact]
+    public void NotBeStatic_Fails_ForAStaticClass()
+    {
+        var type = typeof(Helpers);
+        var ex = Record.Exception(() => type.Should().NotBeStatic());
+        Assert.IsType<AssertionFailedException>(ex);
+        Assert.Equal("Did not expect type to be static.", ex.Message);
+    }
+
+    [Fact]
+    public void NotBeAnInterface_Passes_ForAClass() => typeof(Dog).Should().NotBeAnInterface();
+
+    [Fact]
+    public void NotBeAnInterface_Fails_ForAnInterface()
+    {
+        var type = typeof(IAnimal);
+        var ex = Record.Exception(() => type.Should().NotBeAnInterface());
+        Assert.IsType<AssertionFailedException>(ex);
+        Assert.Equal("Did not expect type to be an interface.", ex.Message);
+    }
+
+    [Fact]
+    public void NotBeAClass_Passes_ForAnInterfaceAndAStruct()
+    {
+        typeof(IAnimal).Should().NotBeAClass();
+        typeof(int).Should().NotBeAClass();
+    }
+
+    [Fact]
+    public void NotBeAClass_Fails_ForAClass()
+    {
+        var type = typeof(Dog);
+        var ex = Record.Exception(() => type.Should().NotBeAClass());
+        Assert.IsType<AssertionFailedException>(ex);
+        Assert.Equal("Did not expect type to be a class.", ex.Message);
+    }
+
+    [Fact]
+    public void TheKindNegatives_All_Pass_ForANullSubject()
+    {
+        Type? type = null;
+        type.Should().NotBeAbstract().And.NotBeSealed().And.NotBeStatic()
+            .And.NotBeAnInterface().And.NotBeAClass();
+    }
+
+    [Fact]
     public void Chaining_Works() => typeof(Dog).Should().BeAClass().And.BeSealed().And.BeAssignableTo<IAnimal>();
 }

--- a/Assertions/MintPlayer.Assertions.Tests/VacuousEquivalencyTests.cs
+++ b/Assertions/MintPlayer.Assertions.Tests/VacuousEquivalencyTests.cs
@@ -1,0 +1,308 @@
+using MintPlayer.Assertions;
+
+namespace MintPlayer.Assertions.Tests;
+
+/// <summary>
+/// Covers the guard against a <em>vacuous</em> equivalency comparison — one in which some node
+/// compares no members, so the positive form passes for any pair of values and the negative form
+/// fails for any pair. Also pins the behaviour of casting to <c>object</c>, which is widely
+/// believed to disable the comparison and does not.
+/// </summary>
+public class VacuousEquivalencyTests
+{
+    private sealed class Invoice
+    {
+        public string Name { get; set; } = "";
+        public int Amount { get; set; }
+    }
+
+    /// <summary>A type with no comparable members: only private state and methods.</summary>
+    private sealed class Marker
+    {
+        private readonly int hidden = 42;
+        public int Reveal() => hidden;
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // The guard fires
+    // ---------------------------------------------------------------------------------------
+
+    [Fact]
+    public void BeEquivalentTo_Throws_WhenExpectationTypeHasNoMembers()
+    {
+        var subject = new Invoice { Name = "ACME", Amount = 10 };
+
+        var ex = Record.Exception(() => subject.Should().BeEquivalentTo(new object()));
+
+        Assert.IsType<InvalidOperationException>(ex);
+        Assert.Contains("No members were compared", ex!.Message);
+        Assert.Contains("can never fail", ex.Message);
+        Assert.Contains("Object", ex.Message);
+        Assert.Contains("Invoice", ex.Message);
+        Assert.Contains("AllowingVacuousComparison()", ex.Message);
+    }
+
+    /// <summary>
+    /// The mirror guard. Without it the negative form fails with "no differences were found",
+    /// which is the confusing symptom that hides the mistake instead of naming it.
+    /// </summary>
+    [Fact]
+    public void NotBeEquivalentTo_Throws_WhenExpectationTypeHasNoMembers()
+    {
+        var subject = new Invoice { Name = "ACME", Amount = 10 };
+
+        var ex = Record.Exception(() => subject.Should().NotBeEquivalentTo(new object()));
+
+        Assert.IsType<InvalidOperationException>(ex);
+        Assert.Contains("No members were compared", ex!.Message);
+    }
+
+    [Fact]
+    public void BeEquivalentTo_Throws_ForEmptyAnonymousExpectation()
+    {
+        var subject = new Invoice { Name = "ACME", Amount = 10 };
+
+        var ex = Record.Exception(() => subject.Should().BeEquivalentTo(new { }));
+
+        Assert.IsType<InvalidOperationException>(ex);
+        Assert.Contains("No members were compared", ex!.Message);
+    }
+
+    [Fact]
+    public void BeEquivalentTo_Throws_WhenExpectationTypeExposesOnlyNonPublicMembers()
+    {
+        var subject = new Invoice { Name = "ACME", Amount = 10 };
+
+        var ex = Record.Exception(() => subject.Should().BeEquivalentTo(new Marker()));
+
+        Assert.IsType<InvalidOperationException>(ex);
+        Assert.Contains("Marker", ex!.Message);
+        Assert.Contains("no public properties or fields", ex.Message);
+    }
+
+    /// <summary>
+    /// The second cause, which needs a different cure and so gets a different message: the
+    /// expectation has members, but the configured options removed every one of them.
+    /// </summary>
+    [Fact]
+    public void BeEquivalentTo_Throws_WhenOptionsExcludeEveryMember()
+    {
+        var subject = new Invoice { Name = "ACME", Amount = 10 };
+        var expectation = new Invoice { Name = "Other", Amount = 99 };
+
+        var ex = Record.Exception(() => subject.Should().BeEquivalentTo(expectation,
+            o => o.Excluding(x => x.Name).Excluding(x => x.Amount)));
+
+        Assert.IsType<InvalidOperationException>(ex);
+        Assert.Contains("removed by the configured", ex!.Message);
+        Assert.Contains("Keep at least one member", ex.Message);
+        Assert.DoesNotContain("no public properties or fields", ex.Message);
+    }
+
+    [Fact]
+    public void BeEquivalentTo_Throws_WhenOnlyExcludedPathsRemain()
+    {
+        var subject = new Invoice { Name = "ACME", Amount = 10 };
+        var expectation = new Invoice { Name = "Other", Amount = 99 };
+
+        var ex = Record.Exception(() => subject.Should().BeEquivalentTo(expectation, o => o.ExcludingPath("*")));
+
+        Assert.IsType<InvalidOperationException>(ex);
+        Assert.Contains("No members were compared", ex!.Message);
+    }
+
+    /// <summary>
+    /// Nested vacuity: the collection lengths really are compared, so a guard that only counted
+    /// whole-comparison assertions would see one real assertion and stay quiet while every element
+    /// comparison asserted nothing. This is the case FluentAssertions' root-only guard misses.
+    /// </summary>
+    [Fact]
+    public void BeEquivalentTo_Throws_WhenNestedElementComparisonIsVacuous()
+    {
+        object[] subject = [new Invoice { Name = "ACME", Amount = 10 }];
+        object[] expectation = [new object()];
+
+        var ex = Record.Exception(() => ((object)subject).Should().BeEquivalentTo(expectation));
+
+        Assert.IsType<InvalidOperationException>(ex);
+        Assert.Contains("No members were compared", ex!.Message);
+        Assert.Contains("Invoice", ex.Message);
+    }
+
+    /// <summary>
+    /// Excluding every member of a nested type is the idiomatic way to say "do not compare this
+    /// subtree" — the package README documents exactly this for an audit-timestamp type whose
+    /// only member is the timestamp. It must not be refused, even though that node ends up
+    /// comparing nothing, because the assertion as a whole still asserts plenty.
+    /// </summary>
+    [Fact]
+    public void BeEquivalentTo_Allows_ExcludingEveryMemberOfANestedType()
+    {
+        var subject = new { Name = "ACME", Audit = new Audit { ModifiedOn = new DateTime(2026, 1, 1) } };
+        var expectation = new { Name = "ACME", Audit = new Audit { ModifiedOn = new DateTime(1999, 9, 9) } };
+
+        subject.Should().BeEquivalentTo(expectation, o => o.ExcludingNested<Audit>(x => x.ModifiedOn));
+    }
+
+    /// <summary>
+    /// The counterpart: at the <em>root</em> there is nothing else left to assert, so excluding
+    /// every member is still refused. This is the line the guard draws between the two cases.
+    /// </summary>
+    [Fact]
+    public void BeEquivalentTo_Throws_WhenEveryMemberIsExcludedAtTheRoot()
+    {
+        var subject = new Audit { ModifiedOn = new DateTime(2026, 1, 1) };
+        var expectation = new Audit { ModifiedOn = new DateTime(1999, 9, 9) };
+
+        var ex = Record.Exception(() => subject.Should().BeEquivalentTo(expectation,
+            o => o.ExcludingNested<Audit>(x => x.ModifiedOn)));
+
+        Assert.IsType<InvalidOperationException>(ex);
+    }
+
+    private sealed class Audit
+    {
+        public DateTime ModifiedOn { get; set; }
+    }
+
+    [Fact]
+    public void BeEquivalentTo_Throws_WhenNestedMemberComparisonIsVacuous()
+    {
+        var subject = new { Inner = new Invoice { Name = "ACME", Amount = 10 } };
+        var expectation = new { Inner = (object)new object() };
+
+        var ex = Record.Exception(() => subject.Should().BeEquivalentTo(expectation));
+
+        Assert.IsType<InvalidOperationException>(ex);
+        Assert.Contains("Inner", ex!.Message);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // The guard stays out of the way
+    // ---------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// Two values that both expose no members really are equivalent, so this must not throw —
+    /// it is the false positive that FluentAssertions is most often complained about.
+    /// </summary>
+    [Fact]
+    public void BeEquivalentTo_Passes_ForTwoMemberlessValues()
+    {
+        new object().Should().BeEquivalentTo(new object());
+        new Marker().Should().BeEquivalentTo(new Marker());
+    }
+
+    [Fact]
+    public void BeEquivalentTo_Passes_ForTwoEmptyCollections()
+    {
+        Array.Empty<Invoice>().Should().BeEquivalentTo(Array.Empty<Invoice>());
+    }
+
+    /// <summary>An empty expectation against a populated subject is caught by the length check, not the guard.</summary>
+    [Fact]
+    public void BeEquivalentTo_Fails_Normally_ForEmptyExpectationAgainstPopulatedSubject()
+    {
+        Invoice[] subject = [new() { Name = "ACME", Amount = 10 }];
+
+        var ex = Record.Exception(() => subject.Should().BeEquivalentTo(Array.Empty<Invoice>()));
+
+        Assert.IsType<AssertionFailedException>(ex);
+        Assert.Contains("0 item(s)", ex!.Message);
+    }
+
+    /// <summary>A memberless subject against a member-bearing expectation is a real failure, not vacuity.</summary>
+    [Fact]
+    public void BeEquivalentTo_Fails_Normally_WhenSubjectHasNoMembers()
+    {
+        var ex = Record.Exception(() => new object().Should().BeEquivalentTo(new Invoice { Name = "ACME", Amount = 10 }));
+
+        Assert.IsType<AssertionFailedException>(ex);
+        Assert.Contains("expectation has member Name but subject does not", ex!.Message);
+    }
+
+    [Fact]
+    public void AllowingVacuousComparison_OptsOutOfTheGuard()
+    {
+        var subject = new Invoice { Name = "ACME", Amount = 10 };
+
+        subject.Should().BeEquivalentTo(new object(), o => o.AllowingVacuousComparison());
+
+        var ex = Record.Exception(() => subject.Should().NotBeEquivalentTo(
+            new object(), o => o.AllowingVacuousComparison()));
+
+        // Opted in, so the negative form now reports the ordinary "no differences" failure
+        // instead of refusing the comparison.
+        Assert.IsType<AssertionFailedException>(ex);
+        Assert.Contains("no differences were found", ex!.Message);
+    }
+
+    /// <summary>
+    /// A root-level custom comparer replaces the member walk entirely, so it is a deliberate
+    /// statement that members are not what should be compared — not a mistake to refuse.
+    /// </summary>
+    [Fact]
+    public void BeEquivalentTo_Passes_WhenRootCustomComparerReplacesTheMemberWalk()
+    {
+        var subject = new Invoice { Name = "ACME", Amount = 10 };
+        var expectation = new Invoice { Name = "Other", Amount = 99 };
+
+        subject.Should().BeEquivalentTo(expectation, o => o.Using<Invoice>((_, _) => { }));
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Casting to object does not disable the comparison (issue #177's premise)
+    // ---------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// Erasing both sides to <c>object</c> is widely believed to silently disable the comparison.
+    /// It does not: <c>ResolveNodeType</c> maps a declared <c>object</c> back to the runtime type,
+    /// so the real members are still walked. It costs the generated accessors (see MPA0004) and
+    /// makes the options lambda untypeable, but the verdict is correct.
+    /// </summary>
+    [Fact]
+    public void BeEquivalentTo_StillComparesMembers_WhenBothSidesAreErasedToObject()
+    {
+        var actual = new Invoice { Name = "John", Amount = 30 };
+        var expected = new Invoice { Name = "Jane", Amount = 31 };
+
+        var ex = Record.Exception(() => ((object)actual).Should().BeEquivalentTo((object)expected));
+
+        Assert.IsType<AssertionFailedException>(ex);
+        Assert.Contains("Name", ex!.Message);
+        Assert.Contains("Amount", ex.Message);
+    }
+
+    [Fact]
+    public void NotBeEquivalentTo_Passes_WhenBothSidesAreErasedToObjectAndDiffer()
+    {
+        var actual = new Invoice { Name = "John", Amount = 30 };
+        var expected = new Invoice { Name = "Jane", Amount = 31 };
+
+        ((object)actual).Should().NotBeEquivalentTo((object)expected);
+    }
+
+    /// <summary>The control that proves the erased comparison is not simply always-failing.</summary>
+    [Fact]
+    public void NotBeEquivalentTo_Fails_WhenBothSidesAreErasedToObjectAndMatch()
+    {
+        var actual = new Invoice { Name = "John", Amount = 30 };
+        var expected = new Invoice { Name = "John", Amount = 30 };
+
+        var ex = Record.Exception(() => ((object)actual).Should().NotBeEquivalentTo((object)expected));
+
+        Assert.IsType<AssertionFailedException>(ex);
+        Assert.Contains("no differences were found", ex!.Message);
+    }
+
+    [Fact]
+    public void BeEquivalentTo_StillComparesItems_WhenErasedArraysDiffer()
+    {
+        Invoice[] actual = [new() { Name = "John", Amount = 30 }];
+        Invoice[] expected = [new() { Name = "Jane", Amount = 31 }];
+
+        var ex = Record.Exception(() => ((object)actual).Should().BeEquivalentTo((object)expected));
+
+        Assert.IsType<AssertionFailedException>(ex);
+        Assert.Contains("no equivalent item was found", ex!.Message);
+    }
+}

--- a/Assertions/MintPlayer.Assertions/Collections/GenericCollectionAssertions.cs
+++ b/Assertions/MintPlayer.Assertions/Collections/GenericCollectionAssertions.cs
@@ -90,6 +90,22 @@ public class GenericCollectionAssertions<T> : ReferenceTypeAssertions<IEnumerabl
         return new(this);
     }
 
+    /// <summary>
+    /// Asserts the collection does not contain exactly <paramref name="unexpected"/> items. Says
+    /// nothing about whether the real count is higher or lower — reach for
+    /// <see cref="HaveCountGreaterThan"/> or <see cref="HaveCountLessThan"/> when the direction is
+    /// what actually matters, since those produce a far more useful failure message.
+    /// </summary>
+    public AndConstraint<GenericCollectionAssertions<T>> NotHaveCount(int unexpected, string? because = null, params object?[] becauseArgs)
+    {
+        var items = Items;
+        if (items is null) return FailNull($"not to contain {unexpected} item(s)", because, becauseArgs);
+
+        Assert().ForCondition(items.Count != unexpected).BecauseOf(because, becauseArgs)
+            .FailWith("Did not expect {subject} to contain {0} item(s){reason}, but found {1}.", unexpected, items);
+        return new(this);
+    }
+
     /// <summary>Asserts the collection's count matches the given predicate.</summary>
     public AndConstraint<GenericCollectionAssertions<T>> HaveCount(Func<int, bool> predicate, string? because = null, params object?[] becauseArgs)
     {
@@ -219,6 +235,47 @@ public class GenericCollectionAssertions<T> : ReferenceTypeAssertions<IEnumerabl
         return new(this, matches.Count >= 1 ? matches[0] : default!);
     }
 
+    /// <summary>
+    /// Asserts the collection does not contain exactly one item — it is either empty or holds two
+    /// or more.
+    /// </summary>
+    /// <remarks>
+    /// Unlike <see cref="ContainSingle(string?, object?[])"/> this returns a plain
+    /// <see cref="AndConstraint{T}"/> rather than an <c>AndWhichConstraint</c>: when the assertion
+    /// succeeds there is by definition no single item to hand back through <c>Which</c>.
+    /// </remarks>
+    public AndConstraint<GenericCollectionAssertions<T>> NotContainSingle(string? because = null, params object?[] becauseArgs)
+    {
+        var items = Items;
+        if (items is null) return FailNull("not to contain a single item", because, becauseArgs);
+
+        Assert().ForCondition(items.Count != 1).BecauseOf(because, becauseArgs)
+            .FailWith("Did not expect {subject} to contain a single item{reason}, but found {0}.", items);
+        return new(this);
+    }
+
+    /// <summary>
+    /// Asserts the number of items matching the predicate is anything but exactly one — zero
+    /// matches satisfies this just as well as three do. To assert that <em>no</em> item matches,
+    /// use <see cref="NotContain(Func{T, bool}, string?, object?[])"/> instead.
+    /// </summary>
+    public AndConstraint<GenericCollectionAssertions<T>> NotContainSingle(Func<T, bool> predicate, string? because = null, params object?[] becauseArgs)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        var items = Items;
+        if (items is null) return FailNull("not to contain a single item matching the given predicate", because, becauseArgs);
+
+        var matches = new List<T>();
+        foreach (var item in items)
+        {
+            if (predicate(item)) matches.Add(item);
+        }
+
+        Assert().ForCondition(matches.Count != 1).BecauseOf(because, becauseArgs)
+            .FailWith("Did not expect {subject} to contain a single item matching the given predicate{reason}, but found {0}.", matches);
+        return new(this);
+    }
+
     /// <summary>Asserts the collection contains the given item.</summary>
     public AndConstraint<GenericCollectionAssertions<T>> Contain(T expected, string? because = null, params object?[] becauseArgs)
     {
@@ -331,6 +388,43 @@ public class GenericCollectionAssertions<T> : ReferenceTypeAssertions<IEnumerabl
         return new(this);
     }
 
+    /// <summary>
+    /// Asserts the given items do <em>not</em> appear in the collection in the given relative
+    /// order. They may all be present — as long as at least one of them is missing or comes out of
+    /// sequence, this succeeds.
+    /// </summary>
+    public AndConstraint<GenericCollectionAssertions<T>> NotContainInOrder(params T[] unexpected)
+        => NotContainInOrder((IEnumerable<T>)unexpected, null);
+
+    /// <summary>
+    /// Asserts the given items do <em>not</em> appear in the collection in the given relative
+    /// order (a subsequence match), allowing other items in between.
+    /// </summary>
+    /// <remarks>
+    /// An empty <paramref name="unexpected"/> sequence is vacuously contained in order by every
+    /// collection, so this assertion always fails for one — the mirror image of
+    /// <see cref="ContainInOrder(IEnumerable{T}, string?, object?[])"/> always succeeding.
+    /// </remarks>
+    public AndConstraint<GenericCollectionAssertions<T>> NotContainInOrder(IEnumerable<T> unexpected, string? because = null, params object?[] becauseArgs)
+    {
+        ArgumentNullException.ThrowIfNull(unexpected);
+        var items = Items;
+        var unexpectedItems = unexpected as IReadOnlyList<T> ?? [.. unexpected];
+        if (items is null) return FailNull($"not to contain {Formatting.Formatter.Format(unexpectedItems)} in order", because, becauseArgs);
+
+        var comparer = EqualityComparer<T>.Default;
+        var position = 0;
+        foreach (var item in items)
+        {
+            if (position < unexpectedItems.Count && comparer.Equals(item, unexpectedItems[position]))
+                position++;
+        }
+
+        Assert().ForCondition(position < unexpectedItems.Count).BecauseOf(because, becauseArgs)
+            .FailWith("Did not expect {subject} to contain {0} in order{reason}, but found {1}.", unexpectedItems, items);
+        return new(this);
+    }
+
     /// <summary>Asserts every item matches the predicate.</summary>
     public AndConstraint<GenericCollectionAssertions<T>> OnlyContain(Func<T, bool> predicate, string? because = null, params object?[] becauseArgs)
     {
@@ -346,6 +440,40 @@ public class GenericCollectionAssertions<T> : ReferenceTypeAssertions<IEnumerabl
 
         Assert().ForCondition(mismatches.Count == 0).BecauseOf(because, becauseArgs)
             .FailWith("Expected {subject} to only contain items matching the given predicate{reason}, but {0} did not.", mismatches);
+        return new(this);
+    }
+
+    /// <summary>
+    /// Asserts at least one item does <em>not</em> match the predicate — the exact logical negation
+    /// of <see cref="OnlyContain"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is deliberately <em>not</em> "contains none of the matching items"; that assertion is
+    /// <see cref="NotContain(Func{T, bool}, string?, object?[])"/>. A collection holding a mix of
+    /// matching and non-matching items satisfies this one, because it is not true that it contains
+    /// <em>only</em> matching items.
+    /// </para>
+    /// <para>
+    /// Because <see cref="OnlyContain"/> is a universally quantified claim, it holds vacuously for
+    /// an empty collection — so this negation fails for an empty collection. If the intent is
+    /// really "no item matches", say that with <c>NotContain(predicate)</c>, which passes on empty.
+    /// </para>
+    /// </remarks>
+    public AndConstraint<GenericCollectionAssertions<T>> NotOnlyContain(Func<T, bool> predicate, string? because = null, params object?[] becauseArgs)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        var items = Items;
+        if (items is null) return FailNull("not to only contain items matching the given predicate", because, becauseArgs);
+
+        var allMatch = true;
+        foreach (var item in items)
+        {
+            if (!predicate(item)) { allMatch = false; break; }
+        }
+
+        Assert().ForCondition(!allMatch).BecauseOf(because, becauseArgs)
+            .FailWith("Did not expect {subject} to only contain items matching the given predicate{reason}, but all {0} item(s) did.", items.Count);
         return new(this);
     }
 
@@ -366,6 +494,59 @@ public class GenericCollectionAssertions<T> : ReferenceTypeAssertions<IEnumerabl
 
         Assert().ForCondition(duplicatesInOrder.Count == 0).BecauseOf(because, becauseArgs)
             .FailWith("Expected {subject} to only have unique items{reason}, but found duplicate(s) {0}.", duplicatesInOrder);
+        return new(this);
+    }
+
+    /// <summary>
+    /// Asserts the collection holds at least one duplicate item, using
+    /// <see cref="EqualityComparer{T}.Default"/> — the negation of
+    /// <see cref="OnlyHaveUniqueItems"/>.
+    /// </summary>
+    /// <remarks>
+    /// Uniqueness holds vacuously for an empty or single-item collection, so this assertion fails
+    /// for both. It is a genuine assertion about duplication, not a weaker "may contain
+    /// duplicates".
+    /// </remarks>
+    public AndConstraint<GenericCollectionAssertions<T>> NotOnlyHaveUniqueItems(string? because = null, params object?[] becauseArgs)
+    {
+        var items = Items;
+        if (items is null) return FailNull("not to only have unique items", because, becauseArgs);
+
+        var seen = new HashSet<T>();
+        var hasDuplicate = false;
+        foreach (var item in items)
+        {
+            if (!seen.Add(item)) { hasDuplicate = true; break; }
+        }
+
+        Assert().ForCondition(hasDuplicate).BecauseOf(because, becauseArgs)
+            .FailWith("Did not expect {subject} to only have unique items{reason}, but found {0}.", items);
+        return new(this);
+    }
+
+    /// <summary>
+    /// Asserts the collection holds at least one <see langword="null"/> item — the positive mirror
+    /// of <see cref="NotContainNulls"/>.
+    /// </summary>
+    /// <remarks>
+    /// Like its negative counterpart there is no nullability constraint on <typeparamref name="T"/>,
+    /// so this compiles for a non-nullable value type too — where it can never succeed, because no
+    /// such item is ever <see langword="null"/>. The failure message reports the collection so that
+    /// case is obvious rather than mysterious.
+    /// </remarks>
+    public AndConstraint<GenericCollectionAssertions<T>> ContainNulls(string? because = null, params object?[] becauseArgs)
+    {
+        var items = Items;
+        if (items is null) return FailNull("to contain <null> items", because, becauseArgs);
+
+        var containsNull = false;
+        for (var i = 0; i < items.Count; i++)
+        {
+            if (items[i] is null) { containsNull = true; break; }
+        }
+
+        Assert().ForCondition(containsNull).BecauseOf(because, becauseArgs)
+            .FailWith("Expected {subject} to contain <null> items{reason}, but found {0}.", items);
         return new(this);
     }
 
@@ -470,6 +651,54 @@ public class GenericCollectionAssertions<T> : ReferenceTypeAssertions<IEnumerabl
         return new(this);
     }
 
+    /// <summary>
+    /// Asserts the collection's first item is not <paramref name="unexpected"/>, mirroring
+    /// <c>string.Should().NotStartWith(...)</c>.
+    /// </summary>
+    /// <remarks>
+    /// An empty collection starts with nothing at all, so it satisfies this. That is why the
+    /// positive <see cref="StartWith(T, string?, object?[])"/> needs a separate "the collection is
+    /// empty" failure and this one does not.
+    /// </remarks>
+    public AndConstraint<GenericCollectionAssertions<T>> NotStartWith(T unexpected, string? because = null, params object?[] becauseArgs)
+    {
+        var items = Items;
+        if (items is null) return FailNull($"not to start with {Formatting.Formatter.Format(unexpected)}", because, becauseArgs);
+
+        var startsWith = items.Count > 0 && EqualityComparer<T>.Default.Equals(items[0], unexpected);
+
+        Assert().ForCondition(!startsWith).BecauseOf(because, becauseArgs)
+            .FailWith("Did not expect {subject} to start with {0}{reason}.", unexpected);
+        return new(this);
+    }
+
+    /// <summary>
+    /// Asserts the collection does not begin with the given sequence of items. A collection shorter
+    /// than <paramref name="unexpected"/> cannot begin with it, so it satisfies this.
+    /// </summary>
+    /// <remarks>
+    /// An empty <paramref name="unexpected"/> sequence prefixes every collection, so this assertion
+    /// always fails for one.
+    /// </remarks>
+    public AndConstraint<GenericCollectionAssertions<T>> NotStartWith(IEnumerable<T> unexpected, string? because = null, params object?[] becauseArgs)
+    {
+        ArgumentNullException.ThrowIfNull(unexpected);
+        var items = Items;
+        var unexpectedItems = unexpected as IReadOnlyList<T> ?? [.. unexpected];
+        if (items is null) return FailNull($"not to start with {Formatting.Formatter.Format(unexpectedItems)}", because, becauseArgs);
+
+        var comparer = EqualityComparer<T>.Default;
+        var startsWith = items.Count >= unexpectedItems.Count;
+        for (var i = 0; startsWith && i < unexpectedItems.Count; i++)
+        {
+            startsWith = comparer.Equals(items[i], unexpectedItems[i]);
+        }
+
+        Assert().ForCondition(!startsWith).BecauseOf(because, becauseArgs)
+            .FailWith("Did not expect {subject} to start with {0}{reason}.", unexpectedItems);
+        return new(this);
+    }
+
     /// <summary>Asserts the collection ends with the given item.</summary>
     public AndConstraint<GenericCollectionAssertions<T>> EndWith(T expected, string? because = null, params object?[] becauseArgs)
     {
@@ -501,6 +730,48 @@ public class GenericCollectionAssertions<T> : ReferenceTypeAssertions<IEnumerabl
 
         Assert().ForCondition(matches).BecauseOf(because, becauseArgs)
             .FailWith("Expected {subject} to end with {0}{reason}, but found {1}.", expectedItems, items);
+        return new(this);
+    }
+
+    /// <summary>
+    /// Asserts the collection's last item is not <paramref name="unexpected"/>, mirroring
+    /// <c>string.Should().NotEndWith(...)</c>. An empty collection ends with nothing at all, so it
+    /// satisfies this.
+    /// </summary>
+    public AndConstraint<GenericCollectionAssertions<T>> NotEndWith(T unexpected, string? because = null, params object?[] becauseArgs)
+    {
+        var items = Items;
+        if (items is null) return FailNull($"not to end with {Formatting.Formatter.Format(unexpected)}", because, becauseArgs);
+
+        var endsWith = items.Count > 0 && EqualityComparer<T>.Default.Equals(items[^1], unexpected);
+
+        Assert().ForCondition(!endsWith).BecauseOf(because, becauseArgs)
+            .FailWith("Did not expect {subject} to end with {0}{reason}.", unexpected);
+        return new(this);
+    }
+
+    /// <summary>
+    /// Asserts the collection does not finish with the given sequence of items. A collection shorter
+    /// than <paramref name="unexpected"/> cannot finish with it, so it satisfies this; an empty
+    /// <paramref name="unexpected"/> sequence suffixes every collection, so this always fails for one.
+    /// </summary>
+    public AndConstraint<GenericCollectionAssertions<T>> NotEndWith(IEnumerable<T> unexpected, string? because = null, params object?[] becauseArgs)
+    {
+        ArgumentNullException.ThrowIfNull(unexpected);
+        var items = Items;
+        var unexpectedItems = unexpected as IReadOnlyList<T> ?? [.. unexpected];
+        if (items is null) return FailNull($"not to end with {Formatting.Formatter.Format(unexpectedItems)}", because, becauseArgs);
+
+        var comparer = EqualityComparer<T>.Default;
+        var endsWith = items.Count >= unexpectedItems.Count;
+        var offset = items.Count - unexpectedItems.Count;
+        for (var i = 0; endsWith && i < unexpectedItems.Count; i++)
+        {
+            endsWith = comparer.Equals(items[offset + i], unexpectedItems[i]);
+        }
+
+        Assert().ForCondition(!endsWith).BecauseOf(because, becauseArgs)
+            .FailWith("Did not expect {subject} to end with {0}{reason}.", unexpectedItems);
         return new(this);
     }
 
@@ -540,6 +811,75 @@ public class GenericCollectionAssertions<T> : ReferenceTypeAssertions<IEnumerabl
     {
         ArgumentNullException.ThrowIfNull(selector);
         return AssertOrder(new KeyComparer<TKey>(selector), descending: true, because, becauseArgs);
+    }
+
+    /// <summary>
+    /// Asserts the items are <em>not</em> in ascending order using <see cref="Comparer{T}.Default"/>
+    /// — that is, some item is followed by a strictly smaller one.
+    /// </summary>
+    /// <remarks>
+    /// Being ordered is a claim about every adjacent pair, so it holds vacuously for an empty or
+    /// single-item collection and this negation fails for both. Note also that a collection of all
+    /// equal items is <em>both</em> ascending and descending, so it fails this and
+    /// <see cref="NotBeInDescendingOrder(string?, object?[])"/> alike.
+    /// </remarks>
+    public AndConstraint<GenericCollectionAssertions<T>> NotBeInAscendingOrder(string? because = null, params object?[] becauseArgs)
+        => NotBeInAscendingOrder(Comparer<T>.Default, because, becauseArgs);
+
+    /// <summary>Asserts the items are not in ascending order according to the given comparer.</summary>
+    public AndConstraint<GenericCollectionAssertions<T>> NotBeInAscendingOrder(IComparer<T> comparer, string? because = null, params object?[] becauseArgs)
+    {
+        ArgumentNullException.ThrowIfNull(comparer);
+        return AssertNotOrder(comparer, descending: false, because, becauseArgs);
+    }
+
+    /// <summary>Asserts the items are not in ascending order by the given key.</summary>
+    public AndConstraint<GenericCollectionAssertions<T>> NotBeInAscendingOrder<TKey>(Func<T, TKey> selector, string? because = null, params object?[] becauseArgs)
+        where TKey : IComparable<TKey>
+    {
+        ArgumentNullException.ThrowIfNull(selector);
+        return AssertNotOrder(new KeyComparer<TKey>(selector), descending: false, because, becauseArgs);
+    }
+
+    /// <summary>
+    /// Asserts the items are <em>not</em> in descending order using
+    /// <see cref="Comparer{T}.Default"/> — that is, some item is followed by a strictly larger one.
+    /// Fails for an empty or single-item collection, which is vacuously ordered.
+    /// </summary>
+    public AndConstraint<GenericCollectionAssertions<T>> NotBeInDescendingOrder(string? because = null, params object?[] becauseArgs)
+        => NotBeInDescendingOrder(Comparer<T>.Default, because, becauseArgs);
+
+    /// <summary>Asserts the items are not in descending order according to the given comparer.</summary>
+    public AndConstraint<GenericCollectionAssertions<T>> NotBeInDescendingOrder(IComparer<T> comparer, string? because = null, params object?[] becauseArgs)
+    {
+        ArgumentNullException.ThrowIfNull(comparer);
+        return AssertNotOrder(comparer, descending: true, because, becauseArgs);
+    }
+
+    /// <summary>Asserts the items are not in descending order by the given key.</summary>
+    public AndConstraint<GenericCollectionAssertions<T>> NotBeInDescendingOrder<TKey>(Func<T, TKey> selector, string? because = null, params object?[] becauseArgs)
+        where TKey : IComparable<TKey>
+    {
+        ArgumentNullException.ThrowIfNull(selector);
+        return AssertNotOrder(new KeyComparer<TKey>(selector), descending: true, because, becauseArgs);
+    }
+
+    private AndConstraint<GenericCollectionAssertions<T>> AssertNotOrder(IComparer<T> comparer, bool descending, string? because, object?[] becauseArgs)
+    {
+        var direction = descending ? "descending" : "ascending";
+        var items = Items;
+        if (items is null) return FailNull($"not to be in {direction} order", because, becauseArgs);
+
+        var ordered = true;
+        for (var i = 1; ordered && i < items.Count; i++)
+        {
+            var comparison = comparer.Compare(items[i - 1], items[i]);
+            if (descending ? comparison < 0 : comparison > 0) ordered = false;
+        }
+
+        Assert().ForCondition(!ordered).BecauseOf(because, becauseArgs)
+            .FailWith("Did not expect {subject} to be in " + direction + " order{reason}, but found {0}.", items);
+        return new(this);
     }
 
     private AndConstraint<GenericCollectionAssertions<T>> AssertOrder(IComparer<T> comparer, bool descending, string? because, object?[] becauseArgs)
@@ -769,6 +1109,52 @@ public class GenericCollectionAssertions<T> : ReferenceTypeAssertions<IEnumerabl
                 return new(this);
             }
         }
+        return new(this);
+    }
+
+    /// <summary>
+    /// Asserts at least one item is <em>not</em> exactly of type <typeparamref name="TExpected"/> —
+    /// a derived type or a <see langword="null"/> item counts as "not", exactly as it does for
+    /// <see cref="AllBeOfType{TExpected}"/>.
+    /// </summary>
+    /// <remarks>
+    /// This is the logical negation of a universally quantified claim, so it fails for an empty
+    /// collection, which vacuously has all its items of any type you like. It does not mean "no item
+    /// is of this type"; a mixed collection satisfies it.
+    /// </remarks>
+    public AndConstraint<GenericCollectionAssertions<T>> NotAllBeOfType<TExpected>(string? because = null, params object?[] becauseArgs)
+    {
+        var items = Items;
+        if (items is null) return FailNull($"not to all be of type {typeof(TExpected).FullName}", because, becauseArgs);
+
+        var allMatch = true;
+        for (var i = 0; allMatch && i < items.Count; i++)
+        {
+            if (items[i]?.GetType() != typeof(TExpected)) allMatch = false;
+        }
+
+        Assert().ForCondition(!allMatch).BecauseOf(because, becauseArgs)
+            .FailWith("Did not expect {subject} to all be of type {0}{reason}, but all {1} item(s) are.", typeof(TExpected), items.Count);
+        return new(this);
+    }
+
+    /// <summary>
+    /// Asserts at least one item is <em>not</em> assignable to <typeparamref name="TExpected"/>.
+    /// Fails for an empty collection, which is vacuously all-assignable to anything.
+    /// </summary>
+    public AndConstraint<GenericCollectionAssertions<T>> NotAllBeAssignableTo<TExpected>(string? because = null, params object?[] becauseArgs)
+    {
+        var items = Items;
+        if (items is null) return FailNull($"not to all be assignable to {typeof(TExpected).FullName}", because, becauseArgs);
+
+        var allMatch = true;
+        for (var i = 0; allMatch && i < items.Count; i++)
+        {
+            if (items[i] is not TExpected) allMatch = false;
+        }
+
+        Assert().ForCondition(!allMatch).BecauseOf(because, becauseArgs)
+            .FailWith("Did not expect {subject} to all be assignable to {0}{reason}, but all {1} item(s) are.", typeof(TExpected), items.Count);
         return new(this);
     }
 

--- a/Assertions/MintPlayer.Assertions/Collections/GenericDictionaryAssertions.cs
+++ b/Assertions/MintPlayer.Assertions/Collections/GenericDictionaryAssertions.cs
@@ -104,6 +104,21 @@ public class GenericDictionaryAssertions<TKey, TValue> : ReferenceTypeAssertions
         return new(this);
     }
 
+    /// <summary>
+    /// Asserts the dictionary does not contain exactly <paramref name="unexpected"/> items. Says
+    /// nothing about the direction of the difference, so prefer an explicit count assertion when
+    /// that is what the test really means.
+    /// </summary>
+    public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> NotHaveCount(int unexpected, string? because = null, params object?[] becauseArgs)
+    {
+        var pairs = Pairs;
+        if (pairs is null) return FailNull($"not to contain {unexpected} item(s)", because, becauseArgs);
+
+        Assert().ForCondition(pairs.Count != unexpected).BecauseOf(because, becauseArgs)
+            .FailWith("Did not expect {subject} to contain {0} item(s){reason}, but found {1}.", unexpected, pairs);
+        return new(this);
+    }
+
     /// <summary>Asserts the dictionary contains the given key, and exposes its value via Which.</summary>
     public AndWhichConstraint<GenericDictionaryAssertions<TKey, TValue>, TValue> ContainKey(TKey expected, string? because = null, params object?[] becauseArgs)
     {
@@ -155,6 +170,42 @@ public class GenericDictionaryAssertions<TKey, TValue> : ReferenceTypeAssertions
 
         Assert().ForCondition(!found).BecauseOf(because, becauseArgs)
             .FailWith("Did not expect {subject} to contain key {0}{reason}.", unexpected);
+        return new(this);
+    }
+
+    /// <summary>Asserts the dictionary contains none of the given keys.</summary>
+    public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> NotContainKeys(params TKey[] unexpected)
+        => NotContainKeys((IEnumerable<TKey>)unexpected, null);
+
+    /// <summary>Asserts the dictionary contains none of the given keys.</summary>
+    /// <remarks>
+    /// <para>
+    /// This is <see cref="NotContainKey"/> applied to every key, not the strict logical negation of
+    /// <see cref="ContainKeys(IEnumerable{TKey}, string?, object?[])"/> — which would be satisfied by
+    /// merely <em>one</em> key being absent while the rest are present, an assertion nobody wants to
+    /// write. So a dictionary holding some but not all of the given keys fails here.
+    /// </para>
+    /// <para>
+    /// Lookups go through the subject's own equality comparer, so a dictionary built with
+    /// <c>StringComparer.OrdinalIgnoreCase</c> correctly reports <c>"ALICE"</c> as present when it
+    /// holds <c>"alice"</c>.
+    /// </para>
+    /// </remarks>
+    public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> NotContainKeys(IEnumerable<TKey> unexpected, string? because = null, params object?[] becauseArgs)
+    {
+        ArgumentNullException.ThrowIfNull(unexpected);
+        var pairs = Pairs;
+        var unexpectedKeys = unexpected as IReadOnlyList<TKey> ?? [.. unexpected];
+        if (pairs is null) return FailNull($"not to contain keys {Formatting.Formatter.Format(unexpectedKeys)}", because, becauseArgs);
+
+        var presentKeys = new List<TKey>();
+        foreach (var key in unexpectedKeys)
+        {
+            if (TryGetValueForKey(key, out _)) presentKeys.Add(key);
+        }
+
+        Assert().ForCondition(presentKeys.Count == 0).BecauseOf(because, becauseArgs)
+            .FailWith("Did not expect {subject} to contain keys {0}{reason}, but found key(s) {1}.", unexpectedKeys, presentKeys);
         return new(this);
     }
 
@@ -223,6 +274,41 @@ public class GenericDictionaryAssertions<TKey, TValue> : ReferenceTypeAssertions
         return new(this);
     }
 
+    /// <summary>Asserts the dictionary contains none of the given values.</summary>
+    public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> NotContainValues(params TValue[] unexpected)
+        => NotContainValues((IEnumerable<TValue>)unexpected, null);
+
+    /// <summary>Asserts the dictionary contains none of the given values.</summary>
+    /// <remarks>
+    /// As with <see cref="NotContainKeys(IEnumerable{TKey}, string?, object?[])"/> this is
+    /// <see cref="NotContainValue"/> applied to every value rather than the strict negation of
+    /// <see cref="ContainValues(IEnumerable{TValue}, string?, object?[])"/>: a dictionary holding
+    /// even one of them fails. Values, unlike keys, are always compared with
+    /// <see cref="EqualityComparer{T}.Default"/> — a dictionary's own comparer applies to its keys
+    /// only.
+    /// </remarks>
+    public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> NotContainValues(IEnumerable<TValue> unexpected, string? because = null, params object?[] becauseArgs)
+    {
+        ArgumentNullException.ThrowIfNull(unexpected);
+        var pairs = Pairs;
+        var unexpectedValues = unexpected as IReadOnlyList<TValue> ?? [.. unexpected];
+        if (pairs is null) return FailNull($"not to contain values {Formatting.Formatter.Format(unexpectedValues)}", because, becauseArgs);
+
+        var comparer = EqualityComparer<TValue>.Default;
+        var presentValues = new List<TValue>();
+        foreach (var value in unexpectedValues)
+        {
+            foreach (var pair in pairs)
+            {
+                if (comparer.Equals(pair.Value, value)) { presentValues.Add(value); break; }
+            }
+        }
+
+        Assert().ForCondition(presentValues.Count == 0).BecauseOf(because, becauseArgs)
+            .FailWith("Did not expect {subject} to contain values {0}{reason}, but found value(s) {1}.", unexpectedValues, presentValues);
+        return new(this);
+    }
+
     /// <summary>Asserts the dictionary contains the given value at the given key.</summary>
     public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> Contain(TKey key, TValue value, string? because = null, params object?[] becauseArgs)
     {
@@ -258,6 +344,14 @@ public class GenericDictionaryAssertions<TKey, TValue> : ReferenceTypeAssertions
             .FailWith("Did not expect {subject} to contain {0} at key {1}{reason}.", value, key);
         return new(this);
     }
+
+    /// <summary>
+    /// Asserts the dictionary does not hold the given key/value pair. Mirrors
+    /// <see cref="Contain(KeyValuePair{TKey, TValue}, string?, object?[])"/> by forwarding to the
+    /// two-argument form, so an absent key satisfies it just as a different value at that key does.
+    /// </summary>
+    public AndConstraint<GenericDictionaryAssertions<TKey, TValue>> NotContain(KeyValuePair<TKey, TValue> unexpected, string? because = null, params object?[] becauseArgs)
+        => NotContain(unexpected.Key, unexpected.Value, because, becauseArgs);
 
     private static TValue FirstValueFor(IReadOnlyList<KeyValuePair<TKey, TValue>> pairs, TKey key)
     {

--- a/Assertions/MintPlayer.Assertions/Equivalency/EquivalencyAssertionExtensions.cs
+++ b/Assertions/MintPlayer.Assertions/Equivalency/EquivalencyAssertionExtensions.cs
@@ -9,6 +9,15 @@ namespace MintPlayer.Assertions;
 /// <see cref="object.Equals(object?)"/>. Configure the comparison through the optional
 /// <see cref="EquivalencyOptions{TExpectation}"/> lambda.
 /// </summary>
+/// <remarks>
+/// Every method here rejects a <em>vacuous</em> comparison — one in which some node compares no
+/// members, making the assertion incapable of failing — with an
+/// <see cref="InvalidOperationException"/>. That is a caller mistake rather than an assertion
+/// outcome, so it is thrown rather than reported as a failure: a failure in the negative direction
+/// is exactly what would make <c>NotBeEquivalentTo</c> succeed, which would hide the mistake in
+/// the very place it is easiest to make. Opt out with
+/// <see cref="EquivalencyOptions{TExpectation}.AllowingVacuousComparison"/>.
+/// </remarks>
 public static class EquivalencyAssertionExtensions
 {
     /// <summary>
@@ -24,11 +33,11 @@ public static class EquivalencyAssertionExtensions
         string? because = null,
         params object?[] becauseArgs)
     {
-        var differences = EquivalencyValidator.Validate(assertions.Subject, expectation, BuildOptions(config), typeof(TExpectation));
-        if (differences.Count > 0)
+        var result = Validate(assertions.Subject, expectation, config, typeof(TExpectation));
+        if (result.Differences.Count > 0)
         {
             assertions.Assert().ForCondition(false).BecauseOf(because, becauseArgs)
-                .FailWith(BuildFailureTemplate(differences, assertions.SubjectExpression), expectation);
+                .FailWith(BuildFailureTemplate(result.Differences, assertions.SubjectExpression), expectation);
         }
         return new(assertions);
     }
@@ -41,8 +50,8 @@ public static class EquivalencyAssertionExtensions
         string? because = null,
         params object?[] becauseArgs)
     {
-        var differences = EquivalencyValidator.Validate(assertions.Subject, expectation, BuildOptions(config), typeof(TExpectation));
-        assertions.Assert().ForCondition(differences.Count > 0).BecauseOf(because, becauseArgs)
+        var result = Validate(assertions.Subject, expectation, config, typeof(TExpectation));
+        assertions.Assert().ForCondition(result.Differences.Count > 0).BecauseOf(because, becauseArgs)
             .FailWith("Did not expect {subject} to be equivalent to {0}{reason}, but no differences were found.", expectation);
         return new(assertions);
     }
@@ -60,13 +69,95 @@ public static class EquivalencyAssertionExtensions
         string? because = null,
         params object?[] becauseArgs)
     {
-        var differences = EquivalencyValidator.Validate(assertions.Subject, expectation, BuildOptions(config), typeof(IEnumerable<TExpectation>));
-        if (differences.Count > 0)
+        var result = Validate(assertions.Subject, expectation, config, typeof(IEnumerable<TExpectation>));
+        if (result.Differences.Count > 0)
         {
             assertions.Assert().ForCondition(false).BecauseOf(because, becauseArgs)
-                .FailWith(BuildFailureTemplate(differences, assertions.SubjectExpression), expectation);
+                .FailWith(BuildFailureTemplate(result.Differences, assertions.SubjectExpression), expectation);
         }
         return new(assertions);
+    }
+
+    /// <summary>
+    /// Asserts that the subject collection is <em>not</em> structurally equivalent to
+    /// <paramref name="expectation"/>. The mirror of the collection <c>BeEquivalentTo</c> above:
+    /// without it, the negative form is unreachable from a typed collection and the only way to
+    /// express it is a cast to <c>object</c>, which costs the source-generated member accessors
+    /// and makes the <paramref name="config"/> lambda untypeable.
+    /// </summary>
+    public static AndConstraint<Collections.GenericCollectionAssertions<T>> NotBeEquivalentTo<T, TExpectation>(
+        this Collections.GenericCollectionAssertions<T> assertions,
+        IEnumerable<TExpectation> expectation,
+        Func<EquivalencyOptions<TExpectation>, EquivalencyOptions<TExpectation>>? config = null,
+        string? because = null,
+        params object?[] becauseArgs)
+    {
+        var result = Validate(assertions.Subject, expectation, config, typeof(IEnumerable<TExpectation>));
+        assertions.Assert().ForCondition(result.Differences.Count > 0).BecauseOf(because, becauseArgs)
+            .FailWith("Did not expect {subject} to be equivalent to {0}{reason}, but no differences were found.", expectation);
+        return new(assertions);
+    }
+
+    /// <summary>
+    /// Asserts that the subject dictionary is structurally equivalent to
+    /// <paramref name="expectation"/>: every expected key present with an equivalent value, and no
+    /// unexpected keys. Values are compared with the full object-graph comparison, so a dictionary
+    /// of DTOs can be compared against a dictionary of anonymous objects holding only the
+    /// interesting members.
+    /// </summary>
+    /// <remarks>
+    /// When both sides are real dictionaries the comparison is key-based and reports missing and
+    /// unexpected keys by name. A sequence of key/value pairs that is not a dictionary has no key
+    /// lookup, so it is compared as a collection of pairs instead — same verdict, pair-shaped
+    /// messages.
+    /// </remarks>
+    public static AndConstraint<Collections.GenericDictionaryAssertions<TKey, TValue>> BeEquivalentTo<TKey, TValue, TExpectation>(
+        this Collections.GenericDictionaryAssertions<TKey, TValue> assertions,
+        IEnumerable<KeyValuePair<TKey, TExpectation>> expectation,
+        Func<EquivalencyOptions<TExpectation>, EquivalencyOptions<TExpectation>>? config = null,
+        string? because = null,
+        params object?[] becauseArgs)
+    {
+        var result = Validate(assertions.Subject, expectation, config, typeof(IEnumerable<KeyValuePair<TKey, TExpectation>>));
+        if (result.Differences.Count > 0)
+        {
+            assertions.Assert().ForCondition(false).BecauseOf(because, becauseArgs)
+                .FailWith(BuildFailureTemplate(result.Differences, assertions.SubjectExpression), expectation);
+        }
+        return new(assertions);
+    }
+
+    /// <summary>
+    /// Asserts that the subject dictionary is <em>not</em> structurally equivalent to
+    /// <paramref name="expectation"/>.
+    /// </summary>
+    public static AndConstraint<Collections.GenericDictionaryAssertions<TKey, TValue>> NotBeEquivalentTo<TKey, TValue, TExpectation>(
+        this Collections.GenericDictionaryAssertions<TKey, TValue> assertions,
+        IEnumerable<KeyValuePair<TKey, TExpectation>> expectation,
+        Func<EquivalencyOptions<TExpectation>, EquivalencyOptions<TExpectation>>? config = null,
+        string? because = null,
+        params object?[] becauseArgs)
+    {
+        var result = Validate(assertions.Subject, expectation, config, typeof(IEnumerable<KeyValuePair<TKey, TExpectation>>));
+        assertions.Assert().ForCondition(result.Differences.Count > 0).BecauseOf(because, becauseArgs)
+            .FailWith("Did not expect {subject} to be equivalent to {0}{reason}, but no differences were found.", expectation);
+        return new(assertions);
+    }
+
+    /// <summary>
+    /// Runs the comparison and rejects a vacuous one, so every assertion method above shares the
+    /// same guard by construction instead of repeating the condition.
+    /// </summary>
+    private static ValidationResult Validate<TExpectation>(
+        object? subject, object? expectation,
+        Func<EquivalencyOptions<TExpectation>, EquivalencyOptions<TExpectation>>? config,
+        Type rootDeclaredType)
+    {
+        var options = BuildOptions(config);
+        var result = EquivalencyValidator.Validate(subject, expectation, options, rootDeclaredType);
+        if (result.Vacuity is { } vacuity && !((IEquivalencyOptions)options).AllowVacuousComparison)
+            throw new InvalidOperationException(BuildVacuityMessage(vacuity));
+        return result;
     }
 
     private static EquivalencyOptions<TExpectation> BuildOptions<TExpectation>(
@@ -75,6 +166,28 @@ public static class EquivalencyAssertionExtensions
         var options = new EquivalencyOptions<TExpectation>();
         return config is null ? options : config(options);
     }
+
+    /// <summary>
+    /// Explains a vacuous comparison and names both types, because the cure depends on which of
+    /// the two causes it was: a memberless expectation type, or options that removed every member.
+    /// </summary>
+    private static string BuildVacuityMessage(VacuousNode vacuity)
+    {
+        var where = vacuity.Path.Length == 0 ? "this assertion" : $"the comparison at '{vacuity.Path}'";
+        var cause = vacuity.ExpectationHasNoMembers
+            ? $"the expectation type '{vacuity.ExpectationType.Name}' exposes no public properties or fields, "
+                + $"while the subject '{vacuity.SubjectType.Name}' has "
+                + $"{CountMembers(vacuity.SubjectType)}. Compare against a concrete type, or against an "
+                + "anonymous object listing the members you care about"
+            : $"every member of '{vacuity.ExpectationType.Name}' was removed by the configured "
+                + "exclusions or inclusions. Keep at least one member in the comparison";
+
+        return $"No members were compared, so {where} can never fail: {cause} — "
+            + "or call AllowingVacuousComparison() if comparing nothing is intended.";
+    }
+
+    private static int CountMembers(Type type)
+        => RegistryMemberProvider.Instance.GetMembers(type).Count;
 
     /// <summary>
     /// Builds the failure template with the difference block pre-rendered into it. The block is

--- a/Assertions/MintPlayer.Assertions/Equivalency/EquivalencyOptions.cs
+++ b/Assertions/MintPlayer.Assertions/Equivalency/EquivalencyOptions.cs
@@ -20,6 +20,7 @@ public sealed class EquivalencyOptions<TExpectation> : IEquivalencyOptions
     private bool useStrictOrdering;
     private int maxDepth = 10;
     private bool useRuntimeTypes;
+    private bool allowVacuousComparison;
 
     IReadOnlyCollection<string> IEquivalencyOptions.ExcludedPaths => excludedPaths;
     IReadOnlyDictionary<Type, IReadOnlyCollection<string>> IEquivalencyOptions.NestedExclusions => nestedExclusions;
@@ -31,6 +32,7 @@ public sealed class EquivalencyOptions<TExpectation> : IEquivalencyOptions
     bool IEquivalencyOptions.UseStrictOrdering => useStrictOrdering;
     int IEquivalencyOptions.MaxDepth => maxDepth;
     bool IEquivalencyOptions.UseRuntimeTypes => useRuntimeTypes;
+    bool IEquivalencyOptions.AllowVacuousComparison => allowVacuousComparison;
 
     /// <summary>
     /// Excludes the member selected by <paramref name="selector"/> from the comparison. Chained
@@ -154,6 +156,21 @@ public sealed class EquivalencyOptions<TExpectation> : IEquivalencyOptions
     public EquivalencyOptions<TExpectation> RespectingRuntimeTypes()
     {
         useRuntimeTypes = true;
+        return this;
+    }
+
+    /// <summary>
+    /// Permits a comparison in which some node compares no members at all. Such an assertion
+    /// cannot fail — the positive form passes for any pair of values and the negative form fails
+    /// for any pair — so it is rejected with an <see cref="InvalidOperationException"/> by
+    /// default. Call this when comparing nothing is genuinely intended, as in a generic or
+    /// table-driven harness where some instantiations of the expectation type legitimately expose
+    /// no members. Comparing two empty collections and comparing two memberless values are both
+    /// already allowed and need no opt-in.
+    /// </summary>
+    public EquivalencyOptions<TExpectation> AllowingVacuousComparison()
+    {
+        allowVacuousComparison = true;
         return this;
     }
 

--- a/Assertions/MintPlayer.Assertions/Equivalency/EquivalencyValidator.cs
+++ b/Assertions/MintPlayer.Assertions/Equivalency/EquivalencyValidator.cs
@@ -28,23 +28,32 @@ internal static class EquivalencyValidator
 {
     /// <summary>
     /// Compares <paramref name="subject"/> against <paramref name="expectation"/> and returns all
-    /// differences found (empty when equivalent). <paramref name="rootDeclaredType"/> is the
-    /// static type of the expectation at the call site, used for member resolution and custom
-    /// comparer lookup at the root.
+    /// differences found (empty when equivalent), together with the first vacuous node detected.
+    /// <paramref name="rootDeclaredType"/> is the static type of the expectation at the call site,
+    /// used for member resolution and custom comparer lookup at the root.
     /// </summary>
-    public static List<Difference> Validate(object? subject, object? expectation, IEquivalencyOptions options, Type? rootDeclaredType = null)
+    public static ValidationResult Validate(object? subject, object? expectation, IEquivalencyOptions options, Type? rootDeclaredType = null)
     {
         var differences = new List<Difference>();
         var context = new Context(options);
         CompareNode(context, differences, string.Empty, subject, expectation, rootDeclaredType, 0);
-        return differences;
+        return new(differences, context.Vacuity);
     }
 
-    /// <summary>Per-validation state: the options and the cycle-detection descent stack.</summary>
+    /// <summary>Per-validation state: the options, the cycle-detection descent stack and the first vacuous node.</summary>
     private sealed class Context(IEquivalencyOptions options)
     {
         public IEquivalencyOptions Options { get; } = options;
         public IMemberProvider MemberProvider { get; } = RegistryMemberProvider.Instance;
+
+        /// <summary>
+        /// The first structural node at which nothing was compared, or null when every structural
+        /// node asserted something. Only the first is kept: it is enough to explain the mistake,
+        /// and reporting every node would bury the cause under its consequences.
+        /// </summary>
+        public VacuousNode? Vacuity { get; private set; }
+
+        public void ReportVacuous(VacuousNode node) => Vacuity ??= node;
 
         private readonly HashSet<(object Subject, object Expectation)> descentStack = new(ReferencePairComparer.Instance);
 
@@ -144,6 +153,10 @@ internal static class EquivalencyValidator
         var subjectMembers = context.MemberProvider.GetMembers(subject.GetType());
         var excludedNames = GetNestedExclusions(context.Options, expectationType, subject.GetType());
 
+        // Counts the members that actually took part in the comparison. Zero of them means this
+        // node asserted nothing and therefore cannot fail — see the ValidationResult docs.
+        var comparedMembers = 0;
+
         foreach (var expectationMember in expectationMembers)
         {
             if (excludedNames is not null && excludedNames.Contains(expectationMember.Name)) continue;
@@ -156,13 +169,41 @@ internal static class EquivalencyValidator
             if (subjectMember is null)
             {
                 if (!IsExcluded(context.Options, childPath))
+                {
                     differences.Add(new(childPath, $"expectation has member {expectationMember.Name} but subject does not"));
+                    comparedMembers++;
+                }
                 continue;
             }
+
+            if (IsExcluded(context.Options, childPath)) continue;
+            comparedMembers++;
 
             CompareNode(context, differences, childPath,
                 subjectMember.Getter(subject), expectationMember.Getter(expectation),
                 expectationMember.Type, depth + 1);
+        }
+
+        // A structural node that compared nothing can never fail. Two memberless values really
+        // are equivalent, so the subject must have members for this to count as vacuous at all.
+        if (comparedMembers > 0 || subjectMembers.Count == 0) return;
+
+        // Which of the two causes it is decides where it counts as a mistake.
+        //
+        // An expectation type with no comparable members is never a way to express intent: an
+        // expectation erased to `object`, or a type whose members are all non-public, is a
+        // mistake wherever it appears — including on a collection element or a nested member,
+        // where it would otherwise hide inside an assertion that looks meaningful overall.
+        //
+        // Options that removed every member are different. At the root the whole assertion is
+        // left asserting nothing, so it is still a mistake. Deeper down, excluding every member
+        // of a subtree is the normal way to say "do not compare this subtree" —
+        // ExcludingNested<AuditInfo>(a => a.ModifiedOn) on a type whose only member is
+        // ModifiedOn means exactly that, and refusing it would reject correct, idiomatic use.
+        if (expectationMembers.Count == 0 || path.Length == 0)
+        {
+            context.ReportVacuous(new(path, expectationType, subject.GetType(),
+                ExpectationHasNoMembers: expectationMembers.Count == 0));
         }
     }
 

--- a/Assertions/MintPlayer.Assertions/Equivalency/IEquivalencyOptions.cs
+++ b/Assertions/MintPlayer.Assertions/Equivalency/IEquivalencyOptions.cs
@@ -43,4 +43,10 @@ public interface IEquivalencyOptions
 
     /// <summary>True to resolve expectation members from runtime types instead of declared types.</summary>
     bool UseRuntimeTypes { get; }
+
+    /// <summary>
+    /// True to permit a comparison in which some node compares no members at all — an assertion
+    /// that cannot fail. Rejected by default, because it is nearly always a mistake.
+    /// </summary>
+    bool AllowVacuousComparison { get; }
 }

--- a/Assertions/MintPlayer.Assertions/Equivalency/ValidationResult.cs
+++ b/Assertions/MintPlayer.Assertions/Equivalency/ValidationResult.cs
@@ -1,0 +1,42 @@
+namespace MintPlayer.Assertions.Equivalency;
+
+/// <summary>
+/// A structural node at which the comparison asserted nothing, so it could not have failed.
+/// </summary>
+/// <param name="Path">
+/// The path into the object graph where it happened (empty for the root), so a vacuous node
+/// nested inside an otherwise-meaningful comparison can be pointed at precisely.
+/// </param>
+/// <param name="ExpectationType">The type whose members drove (or failed to drive) the comparison.</param>
+/// <param name="SubjectType">The subject's runtime type at that node.</param>
+/// <param name="ExpectationHasNoMembers">
+/// True when the expectation type exposes no comparable members at all, false when it has members
+/// but every one of them was removed by the configured exclusions or inclusions. The two causes
+/// have different cures, so they get different messages.
+/// </param>
+internal sealed record VacuousNode(
+    string Path,
+    Type ExpectationType,
+    Type SubjectType,
+    bool ExpectationHasNoMembers);
+
+/// <summary>
+/// The outcome of one equivalency validation: the differences found, plus whether the comparison
+/// was <em>vacuous</em> — i.e. some structural node compared nothing at all.
+/// </summary>
+/// <remarks>
+/// The distinction matters because <c>BeEquivalentTo</c> is expectation-driven: it walks the
+/// expectation's members and ignores extra subject members, which is what makes comparing a full
+/// DTO against an anonymous object holding only the interesting members work. The degenerate
+/// consequence is that an expectation contributing zero members yields zero differences, so the
+/// positive assertion passes unconditionally and the negative one fails unconditionally. Such an
+/// assertion reads as a green regression fence over a code path nobody is checking, so the engine
+/// reports it and the assertion methods turn it into a loud error instead of a silent pass.
+/// </remarks>
+/// <param name="Differences">Every structural difference found; empty when equivalent.</param>
+/// <param name="Vacuity">The first node that compared nothing, or null when the comparison was meaningful.</param>
+internal sealed record ValidationResult(List<Difference> Differences, VacuousNode? Vacuity)
+{
+    /// <summary>True when some node compared nothing, making the result meaningless in both directions.</summary>
+    public bool IsVacuous => Vacuity is not null;
+}

--- a/Assertions/MintPlayer.Assertions/MintPlayer.Assertions.csproj
+++ b/Assertions/MintPlayer.Assertions/MintPlayer.Assertions.csproj
@@ -9,7 +9,7 @@
 		<IsAotCompatible>true</IsAotCompatible>
 
 		<IsPackable>true</IsPackable>
-		<Version>1.0.1</Version>
+		<Version>1.1.0</Version>
 		<Authors>Pieterjan De Clippel</Authors>
 		<Company>MintPlayer</Company>
 		<Description>Fluent assertion library for .NET. Free forever (Apache-2.0), AOT/trimming-safe, with source-generated object-graph equivalency and first-class analyzers.</Description>

--- a/Assertions/MintPlayer.Assertions/Primitives/ComparableAssertions.cs
+++ b/Assertions/MintPlayer.Assertions/Primitives/ComparableAssertions.cs
@@ -88,6 +88,14 @@ public class ComparableAssertions<T>
         return new(this);
     }
 
+    /// <summary>Asserts the value lies outside the inclusive range [<paramref name="minimumValue"/>, <paramref name="maximumValue"/>] (a null value passes).</summary>
+    public AndConstraint<ComparableAssertions<T>> NotBeInRange(T minimumValue, T maximumValue, string? because = null, params object?[] becauseArgs)
+    {
+        Assert().ForCondition(!hasValue || Subject!.CompareTo(minimumValue) < 0 || Subject!.CompareTo(maximumValue) > 0).BecauseOf(because, becauseArgs)
+            .FailWith("Did not expect {subject} to be between {0} and {1}{reason}, but found {2}.", minimumValue, maximumValue, SubjectForMessage);
+        return new(this);
+    }
+
     // Renders default(T) of a null reference subject as <null> instead of a misleading default value.
     private object? SubjectForMessage => hasValue ? Subject : null;
 }

--- a/Assertions/MintPlayer.Assertions/Primitives/DateOnlyAssertions.cs
+++ b/Assertions/MintPlayer.Assertions/Primitives/DateOnlyAssertions.cs
@@ -113,6 +113,22 @@ public class DateOnlyAssertions
         return new(this);
     }
 
+    /// <summary>Asserts the subject is none of <paramref name="unexpectedValues"/> (a null subject passes).</summary>
+    public AndConstraint<DateOnlyAssertions> NotBeOneOf(params DateOnly[] unexpectedValues)
+        => NotBeOneOf(unexpectedValues, because: null);
+
+    /// <summary>
+    /// Asserts the subject is none of <paramref name="unexpectedValues"/> (a null subject passes).
+    /// An empty set passes too: there is nothing for the subject to be one of.
+    /// </summary>
+    public AndConstraint<DateOnlyAssertions> NotBeOneOf(DateOnly[] unexpectedValues, string? because = null, params object?[] becauseArgs)
+    {
+        ArgumentNullException.ThrowIfNull(unexpectedValues);
+        Assert().ForCondition(!Subject.HasValue || Array.IndexOf(unexpectedValues, Subject.Value) < 0).BecauseOf(because, becauseArgs)
+            .FailWith("Did not expect {subject} to be one of {0}{reason}, but found {1}.", unexpectedValues, Subject);
+        return new(this);
+    }
+
     private AndConstraint<DateOnlyAssertions> HaveComponent(string name, int expected, int? actual, string? because, object?[] becauseArgs)
     {
         Assert().ForCondition(Subject.HasValue).BecauseOf(because, becauseArgs)

--- a/Assertions/MintPlayer.Assertions/Primitives/DateTimeAssertions.cs
+++ b/Assertions/MintPlayer.Assertions/Primitives/DateTimeAssertions.cs
@@ -114,11 +114,47 @@ public class DateTimeAssertions
     public AndConstraint<DateTimeAssertions> HaveSecond(int expected, string? because = null, params object?[] becauseArgs)
         => HaveComponent("second", expected, Subject?.Second, because, becauseArgs);
 
+    /// <summary>Asserts the subject's year differs from <paramref name="unexpected"/> (a null subject passes).</summary>
+    public AndConstraint<DateTimeAssertions> NotHaveYear(int unexpected, string? because = null, params object?[] becauseArgs)
+        => NotHaveComponent("year", unexpected, Subject?.Year, because, becauseArgs);
+
+    /// <summary>Asserts the subject's month differs from <paramref name="unexpected"/> (a null subject passes).</summary>
+    public AndConstraint<DateTimeAssertions> NotHaveMonth(int unexpected, string? because = null, params object?[] becauseArgs)
+        => NotHaveComponent("month", unexpected, Subject?.Month, because, becauseArgs);
+
+    /// <summary>Asserts the subject's day differs from <paramref name="unexpected"/> (a null subject passes).</summary>
+    public AndConstraint<DateTimeAssertions> NotHaveDay(int unexpected, string? because = null, params object?[] becauseArgs)
+        => NotHaveComponent("day", unexpected, Subject?.Day, because, becauseArgs);
+
+    /// <summary>Asserts the subject's hour differs from <paramref name="unexpected"/> (a null subject passes).</summary>
+    public AndConstraint<DateTimeAssertions> NotHaveHour(int unexpected, string? because = null, params object?[] becauseArgs)
+        => NotHaveComponent("hour", unexpected, Subject?.Hour, because, becauseArgs);
+
+    /// <summary>Asserts the subject's minute differs from <paramref name="unexpected"/> (a null subject passes).</summary>
+    public AndConstraint<DateTimeAssertions> NotHaveMinute(int unexpected, string? because = null, params object?[] becauseArgs)
+        => NotHaveComponent("minute", unexpected, Subject?.Minute, because, becauseArgs);
+
+    /// <summary>Asserts the subject's second differs from <paramref name="unexpected"/> (a null subject passes).</summary>
+    public AndConstraint<DateTimeAssertions> NotHaveSecond(int unexpected, string? because = null, params object?[] becauseArgs)
+        => NotHaveComponent("second", unexpected, Subject?.Second, because, becauseArgs);
+
     /// <summary>Asserts the subject's date component equals that of <paramref name="expected"/> (time of day is ignored).</summary>
     public AndConstraint<DateTimeAssertions> BeSameDateAs(DateTime expected, string? because = null, params object?[] becauseArgs)
     {
         Assert().ForCondition(Subject.HasValue && Subject.Value.Date == expected.Date).BecauseOf(because, becauseArgs)
             .FailWith("Expected {subject} to be on {0}{reason}, but found {1}.", expected.Date, Subject);
+        return new(this);
+    }
+
+    /// <summary>
+    /// Asserts the subject falls on a different calendar day than <paramref name="unexpected"/>
+    /// (time of day is ignored on both sides, so a different clock time on the same day still fails).
+    /// A null subject passes.
+    /// </summary>
+    public AndConstraint<DateTimeAssertions> NotBeSameDateAs(DateTime unexpected, string? because = null, params object?[] becauseArgs)
+    {
+        Assert().ForCondition(!Subject.HasValue || Subject.Value.Date != unexpected.Date).BecauseOf(because, becauseArgs)
+            .FailWith("Did not expect {subject} to be on {0}{reason}, but found {1}.", unexpected.Date, Subject);
         return new(this);
     }
 
@@ -129,6 +165,19 @@ public class DateTimeAssertions
             .FailWith("Expected {subject} to be in {0}{reason}, but found <null>.", expectedKind)
             .ForCondition(!Subject.HasValue || Subject.Value.Kind == expectedKind).BecauseOf(because, becauseArgs)
             .FailWith("Expected {subject} to be in {0}{reason}, but found {1}.", expectedKind, Subject?.Kind);
+        return new(this);
+    }
+
+    /// <summary>
+    /// Asserts the subject's <see cref="DateTime.Kind"/> differs from <paramref name="unexpectedKind"/>.
+    /// A null subject passes — it carries no kind to object to. Note that
+    /// <see cref="DateTimeKind.Unspecified"/> is a kind like any other here, so an unspecified subject
+    /// fails <c>NotBeIn(DateTimeKind.Unspecified)</c>.
+    /// </summary>
+    public AndConstraint<DateTimeAssertions> NotBeIn(DateTimeKind unexpectedKind, string? because = null, params object?[] becauseArgs)
+    {
+        Assert().ForCondition(!Subject.HasValue || Subject.Value.Kind != unexpectedKind).BecauseOf(because, becauseArgs)
+            .FailWith("Did not expect {subject} to be in {0}{reason}.", unexpectedKind);
         return new(this);
     }
 
@@ -161,6 +210,22 @@ public class DateTimeAssertions
         return new(this);
     }
 
+    /// <summary>Asserts the subject is none of <paramref name="unexpectedValues"/> (a null subject passes).</summary>
+    public AndConstraint<DateTimeAssertions> NotBeOneOf(params DateTime[] unexpectedValues)
+        => NotBeOneOf(unexpectedValues, because: null);
+
+    /// <summary>
+    /// Asserts the subject is none of <paramref name="unexpectedValues"/> (a null subject passes).
+    /// An empty set passes too: there is nothing for the subject to be one of.
+    /// </summary>
+    public AndConstraint<DateTimeAssertions> NotBeOneOf(DateTime[] unexpectedValues, string? because = null, params object?[] becauseArgs)
+    {
+        ArgumentNullException.ThrowIfNull(unexpectedValues);
+        Assert().ForCondition(!Subject.HasValue || Array.IndexOf(unexpectedValues, Subject.Value) < 0).BecauseOf(because, becauseArgs)
+            .FailWith("Did not expect {subject} to be one of {0}{reason}, but found {1}.", unexpectedValues, Subject);
+        return new(this);
+    }
+
     private static TimeSpan Distance(DateTime left, DateTime right)
         => TimeSpan.FromTicks(Math.Abs(left.Ticks - right.Ticks));
 
@@ -170,6 +235,14 @@ public class DateTimeAssertions
             .FailWith("Expected {subject} to have " + name + " {0}{reason}, but found <null>.", expected)
             .ForCondition(!Subject.HasValue || actual == expected).BecauseOf(because, becauseArgs)
             .FailWith("Expected {subject} to have " + name + " {0}{reason}, but found {1}.", expected, actual);
+        return new(this);
+    }
+
+    // The negative needs no null stage: without a value there is no component to object to, so null passes.
+    private AndConstraint<DateTimeAssertions> NotHaveComponent(string name, int unexpected, int? actual, string? because, object?[] becauseArgs)
+    {
+        Assert().ForCondition(!Subject.HasValue || actual != unexpected).BecauseOf(because, becauseArgs)
+            .FailWith("Did not expect {subject} to have " + name + " {0}{reason}.", unexpected);
         return new(this);
     }
 }

--- a/Assertions/MintPlayer.Assertions/Primitives/DateTimeOffsetAssertions.cs
+++ b/Assertions/MintPlayer.Assertions/Primitives/DateTimeOffsetAssertions.cs
@@ -114,11 +114,47 @@ public class DateTimeOffsetAssertions
     public AndConstraint<DateTimeOffsetAssertions> HaveSecond(int expected, string? because = null, params object?[] becauseArgs)
         => HaveComponent("second", expected, Subject?.Second, because, becauseArgs);
 
+    /// <summary>Asserts the subject's year differs from <paramref name="unexpected"/> (a null subject passes).</summary>
+    public AndConstraint<DateTimeOffsetAssertions> NotHaveYear(int unexpected, string? because = null, params object?[] becauseArgs)
+        => NotHaveComponent("year", unexpected, Subject?.Year, because, becauseArgs);
+
+    /// <summary>Asserts the subject's month differs from <paramref name="unexpected"/> (a null subject passes).</summary>
+    public AndConstraint<DateTimeOffsetAssertions> NotHaveMonth(int unexpected, string? because = null, params object?[] becauseArgs)
+        => NotHaveComponent("month", unexpected, Subject?.Month, because, becauseArgs);
+
+    /// <summary>Asserts the subject's day differs from <paramref name="unexpected"/> (a null subject passes).</summary>
+    public AndConstraint<DateTimeOffsetAssertions> NotHaveDay(int unexpected, string? because = null, params object?[] becauseArgs)
+        => NotHaveComponent("day", unexpected, Subject?.Day, because, becauseArgs);
+
+    /// <summary>Asserts the subject's hour differs from <paramref name="unexpected"/> (a null subject passes).</summary>
+    public AndConstraint<DateTimeOffsetAssertions> NotHaveHour(int unexpected, string? because = null, params object?[] becauseArgs)
+        => NotHaveComponent("hour", unexpected, Subject?.Hour, because, becauseArgs);
+
+    /// <summary>Asserts the subject's minute differs from <paramref name="unexpected"/> (a null subject passes).</summary>
+    public AndConstraint<DateTimeOffsetAssertions> NotHaveMinute(int unexpected, string? because = null, params object?[] becauseArgs)
+        => NotHaveComponent("minute", unexpected, Subject?.Minute, because, becauseArgs);
+
+    /// <summary>Asserts the subject's second differs from <paramref name="unexpected"/> (a null subject passes).</summary>
+    public AndConstraint<DateTimeOffsetAssertions> NotHaveSecond(int unexpected, string? because = null, params object?[] becauseArgs)
+        => NotHaveComponent("second", unexpected, Subject?.Second, because, becauseArgs);
+
     /// <summary>Asserts the subject's date component equals that of <paramref name="expected"/> (time of day and offset are ignored).</summary>
     public AndConstraint<DateTimeOffsetAssertions> BeSameDateAs(DateTimeOffset expected, string? because = null, params object?[] becauseArgs)
     {
         Assert().ForCondition(Subject.HasValue && Subject.Value.Date == expected.Date).BecauseOf(because, becauseArgs)
             .FailWith("Expected {subject} to be on {0}{reason}, but found {1}.", expected.Date, Subject);
+        return new(this);
+    }
+
+    /// <summary>
+    /// Asserts the subject falls on a different calendar day than <paramref name="unexpected"/>.
+    /// Both sides are compared as their own local date, offsets untranslated — the same instant
+    /// rendered in two zones can therefore sit on two different dates. A null subject passes.
+    /// </summary>
+    public AndConstraint<DateTimeOffsetAssertions> NotBeSameDateAs(DateTimeOffset unexpected, string? because = null, params object?[] becauseArgs)
+    {
+        Assert().ForCondition(!Subject.HasValue || Subject.Value.Date != unexpected.Date).BecauseOf(because, becauseArgs)
+            .FailWith("Did not expect {subject} to be on {0}{reason}, but found {1}.", unexpected.Date, Subject);
         return new(this);
     }
 
@@ -129,6 +165,14 @@ public class DateTimeOffsetAssertions
             .FailWith("Expected {subject} to have offset {0}{reason}, but found <null>.", expected)
             .ForCondition(!Subject.HasValue || Subject.Value.Offset == expected).BecauseOf(because, becauseArgs)
             .FailWith("Expected {subject} to have offset {0}{reason}, but found {1}.", expected, Subject?.Offset);
+        return new(this);
+    }
+
+    /// <summary>Asserts the subject's offset from UTC differs from <paramref name="unexpected"/> (a null subject passes).</summary>
+    public AndConstraint<DateTimeOffsetAssertions> NotHaveOffset(TimeSpan unexpected, string? because = null, params object?[] becauseArgs)
+    {
+        Assert().ForCondition(!Subject.HasValue || Subject.Value.Offset != unexpected).BecauseOf(because, becauseArgs)
+            .FailWith("Did not expect {subject} to have offset {0}{reason}.", unexpected);
         return new(this);
     }
 
@@ -161,6 +205,22 @@ public class DateTimeOffsetAssertions
         return new(this);
     }
 
+    /// <summary>Asserts the subject is none of <paramref name="unexpectedValues"/> (a null subject passes).</summary>
+    public AndConstraint<DateTimeOffsetAssertions> NotBeOneOf(params DateTimeOffset[] unexpectedValues)
+        => NotBeOneOf(unexpectedValues, because: null);
+
+    /// <summary>
+    /// Asserts the subject is none of <paramref name="unexpectedValues"/> (a null subject passes).
+    /// An empty set passes too: there is nothing for the subject to be one of.
+    /// </summary>
+    public AndConstraint<DateTimeOffsetAssertions> NotBeOneOf(DateTimeOffset[] unexpectedValues, string? because = null, params object?[] becauseArgs)
+    {
+        ArgumentNullException.ThrowIfNull(unexpectedValues);
+        Assert().ForCondition(!Subject.HasValue || Array.IndexOf(unexpectedValues, Subject.Value) < 0).BecauseOf(because, becauseArgs)
+            .FailWith("Did not expect {subject} to be one of {0}{reason}, but found {1}.", unexpectedValues, Subject);
+        return new(this);
+    }
+
     private static TimeSpan Distance(DateTimeOffset left, DateTimeOffset right)
         => TimeSpan.FromTicks(Math.Abs(left.UtcTicks - right.UtcTicks));
 
@@ -170,6 +230,14 @@ public class DateTimeOffsetAssertions
             .FailWith("Expected {subject} to have " + name + " {0}{reason}, but found <null>.", expected)
             .ForCondition(!Subject.HasValue || actual == expected).BecauseOf(because, becauseArgs)
             .FailWith("Expected {subject} to have " + name + " {0}{reason}, but found {1}.", expected, actual);
+        return new(this);
+    }
+
+    // The negative needs no null stage: without a value there is no component to object to, so null passes.
+    private AndConstraint<DateTimeOffsetAssertions> NotHaveComponent(string name, int unexpected, int? actual, string? because, object?[] becauseArgs)
+    {
+        Assert().ForCondition(!Subject.HasValue || actual != unexpected).BecauseOf(because, becauseArgs)
+            .FailWith("Did not expect {subject} to have " + name + " {0}{reason}.", unexpected);
         return new(this);
     }
 }

--- a/Assertions/MintPlayer.Assertions/Primitives/EnumAssertions.cs
+++ b/Assertions/MintPlayer.Assertions/Primitives/EnumAssertions.cs
@@ -64,6 +64,17 @@ public class EnumAssertions<TEnum>
         return new(this);
     }
 
+    /// <summary>
+    /// Asserts the value is not one of the declared members of <typeparamref name="TEnum"/> — the check
+    /// for the out-of-range values a cast from an integer can produce (a null value passes).
+    /// </summary>
+    public AndConstraint<EnumAssertions<TEnum>> NotBeDefined(string? because = null, params object?[] becauseArgs)
+    {
+        Assert().ForCondition(Subject is not { } value || !Enum.IsDefined(value)).BecauseOf(because, becauseArgs)
+            .FailWith("Did not expect {subject} to be defined in {0}{reason}, but found {1}.", typeof(TEnum), Subject);
+        return new(this);
+    }
+
     /// <summary>Asserts the value is one of the given values.</summary>
     public AndConstraint<EnumAssertions<TEnum>> BeOneOf(params TEnum[] validValues)
         => BeOneOf(validValues, because: null);
@@ -74,6 +85,22 @@ public class EnumAssertions<TEnum>
         ArgumentNullException.ThrowIfNull(validValues);
         Assert().ForCondition(Subject is { } value && validValues.Contains(value, EqualityComparer<TEnum>.Default)).BecauseOf(because, becauseArgs)
             .FailWith("Expected {subject} to be one of {0}{reason}, but found {1}.", validValues, Subject);
+        return new(this);
+    }
+
+    /// <summary>Asserts the value is none of the given values (a null value passes).</summary>
+    public AndConstraint<EnumAssertions<TEnum>> NotBeOneOf(params TEnum[] unexpectedValues)
+        => NotBeOneOf(unexpectedValues, because: null);
+
+    /// <summary>
+    /// Asserts the value is none of the given values (a null value passes). An empty set passes too:
+    /// there is nothing for the value to be one of.
+    /// </summary>
+    public AndConstraint<EnumAssertions<TEnum>> NotBeOneOf(IEnumerable<TEnum> unexpectedValues, string? because = null, params object?[] becauseArgs)
+    {
+        ArgumentNullException.ThrowIfNull(unexpectedValues);
+        Assert().ForCondition(Subject is not { } value || !unexpectedValues.Contains(value, EqualityComparer<TEnum>.Default)).BecauseOf(because, becauseArgs)
+            .FailWith("Did not expect {subject} to be one of {0}{reason}, but found {1}.", unexpectedValues, Subject);
         return new(this);
     }
 

--- a/Assertions/MintPlayer.Assertions/Primitives/NumericAssertions.cs
+++ b/Assertions/MintPlayer.Assertions/Primitives/NumericAssertions.cs
@@ -58,6 +58,29 @@ public class NumericAssertions<T>
         return new(this);
     }
 
+    /// <summary>
+    /// Asserts the value is not greater than zero. Zero, negatives and null all pass. The condition is
+    /// the exact negation of <see cref="BePositive"/> rather than <c>value &lt;= T.Zero</c>, so NaN — which
+    /// compares false against everything — passes here instead of failing both forms.
+    /// </summary>
+    public AndConstraint<NumericAssertions<T>> NotBePositive(string? because = null, params object?[] becauseArgs)
+    {
+        Assert().ForCondition(Subject is not { } value || !(value > T.Zero)).BecauseOf(because, becauseArgs)
+            .FailWith("Did not expect {subject} to be positive{reason}, but found {0}.", Subject);
+        return new(this);
+    }
+
+    /// <summary>
+    /// Asserts the value is not less than zero. Zero, positives and null all pass; as with
+    /// <see cref="NotBePositive"/> the condition is the exact negation of <see cref="BeNegative"/>, so NaN passes.
+    /// </summary>
+    public AndConstraint<NumericAssertions<T>> NotBeNegative(string? because = null, params object?[] becauseArgs)
+    {
+        Assert().ForCondition(Subject is not { } value || !(value < T.Zero)).BecauseOf(because, becauseArgs)
+            .FailWith("Did not expect {subject} to be negative{reason}, but found {0}.", Subject);
+        return new(this);
+    }
+
     /// <summary>Asserts the value is greater than the expected value.</summary>
     public AndConstraint<NumericAssertions<T>> BeGreaterThan(T expected, string? because = null, params object?[] becauseArgs)
     {
@@ -116,6 +139,22 @@ public class NumericAssertions<T>
         ArgumentNullException.ThrowIfNull(validValues);
         Assert().ForCondition(Subject is { } value && validValues.Contains(value, EqualityComparer<T>.Default)).BecauseOf(because, becauseArgs)
             .FailWith("Expected {subject} to be one of {0}{reason}, but found {1}.", validValues, Subject);
+        return new(this);
+    }
+
+    /// <summary>Asserts the value is none of the given values (a null value passes).</summary>
+    public AndConstraint<NumericAssertions<T>> NotBeOneOf(params T[] unexpectedValues)
+        => NotBeOneOf(unexpectedValues, because: null);
+
+    /// <summary>
+    /// Asserts the value is none of the given values (a null value passes). An empty set passes too:
+    /// there is nothing for the value to be one of.
+    /// </summary>
+    public AndConstraint<NumericAssertions<T>> NotBeOneOf(IEnumerable<T> unexpectedValues, string? because = null, params object?[] becauseArgs)
+    {
+        ArgumentNullException.ThrowIfNull(unexpectedValues);
+        Assert().ForCondition(Subject is not { } value || !unexpectedValues.Contains(value, EqualityComparer<T>.Default)).BecauseOf(because, becauseArgs)
+            .FailWith("Did not expect {subject} to be one of {0}{reason}, but found {1}.", unexpectedValues, Subject);
         return new(this);
     }
 

--- a/Assertions/MintPlayer.Assertions/Primitives/ReferenceTypeAssertions.cs
+++ b/Assertions/MintPlayer.Assertions/Primitives/ReferenceTypeAssertions.cs
@@ -95,4 +95,17 @@ public abstract class ReferenceTypeAssertions<TSubject, TSelf>
             .FailWith("Expected {subject} to match the given predicate{reason}, but {0} did not.", Subject);
         return new((TSelf)this);
     }
+
+    /// <summary>
+    /// Asserts the subject does not match an arbitrary predicate; the predicate text appears in the failure.
+    /// Unlike the other negatives here, a null subject is not automatically a pass: the predicate is
+    /// handed the null and decides, so it must tolerate one.
+    /// </summary>
+    public AndConstraint<TSelf> NotMatch(Func<TSubject?, bool> predicate, string? because = null, params object?[] becauseArgs)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        Assert().ForCondition(!predicate(Subject)).BecauseOf(because, becauseArgs)
+            .FailWith("Did not expect {subject} to match the given predicate{reason}, but {0} did.", Subject);
+        return new((TSelf)this);
+    }
 }

--- a/Assertions/MintPlayer.Assertions/Primitives/StringAssertions.cs
+++ b/Assertions/MintPlayer.Assertions/Primitives/StringAssertions.cs
@@ -118,6 +118,14 @@ public class StringAssertions : ReferenceTypeAssertions<string, StringAssertions
         return new(this);
     }
 
+    /// <summary>Asserts the subject does not have exactly <paramref name="unexpected"/> characters (a null subject passes — it has no length to object to).</summary>
+    public AndConstraint<StringAssertions> NotHaveLength(int unexpected, string? because = null, params object?[] becauseArgs)
+    {
+        Assert().ForCondition(Subject is null || Subject.Length != unexpected).BecauseOf(because, becauseArgs)
+            .FailWith("Did not expect {subject} to have length {0}{reason}.", unexpected);
+        return new(this);
+    }
+
     /// <summary>Asserts the subject starts with <paramref name="expected"/> (ordinal).</summary>
     public AndConstraint<StringAssertions> StartWith(string expected, string? because = null, params object?[] becauseArgs)
     {
@@ -145,6 +153,15 @@ public class StringAssertions : ReferenceTypeAssertions<string, StringAssertions
         return new(this);
     }
 
+    /// <summary>Asserts the subject does not start with <paramref name="unexpected"/>, ignoring casing (a null subject passes).</summary>
+    public AndConstraint<StringAssertions> NotStartWithEquivalentOf(string unexpected, string? because = null, params object?[] becauseArgs)
+    {
+        ArgumentNullException.ThrowIfNull(unexpected);
+        Assert().ForCondition(Subject is null || !Subject.StartsWith(unexpected, StringComparison.OrdinalIgnoreCase)).BecauseOf(because, becauseArgs)
+            .FailWith("Did not expect {subject} to start with the equivalent of {0}{reason}.", unexpected);
+        return new(this);
+    }
+
     /// <summary>Asserts the subject ends with <paramref name="expected"/> (ordinal).</summary>
     public AndConstraint<StringAssertions> EndWith(string expected, string? because = null, params object?[] becauseArgs)
     {
@@ -169,6 +186,15 @@ public class StringAssertions : ReferenceTypeAssertions<string, StringAssertions
         ArgumentNullException.ThrowIfNull(expected);
         Assert().ForCondition(Subject is not null && Subject.EndsWith(expected, StringComparison.OrdinalIgnoreCase)).BecauseOf(because, becauseArgs)
             .FailWith("Expected {subject} to end with the equivalent of {0}{reason}, but found {1}.", expected, Subject);
+        return new(this);
+    }
+
+    /// <summary>Asserts the subject does not end with <paramref name="unexpected"/>, ignoring casing (a null subject passes).</summary>
+    public AndConstraint<StringAssertions> NotEndWithEquivalentOf(string unexpected, string? because = null, params object?[] becauseArgs)
+    {
+        ArgumentNullException.ThrowIfNull(unexpected);
+        Assert().ForCondition(Subject is null || !Subject.EndsWith(unexpected, StringComparison.OrdinalIgnoreCase)).BecauseOf(because, becauseArgs)
+            .FailWith("Did not expect {subject} to end with the equivalent of {0}{reason}.", unexpected);
         return new(this);
     }
 
@@ -222,6 +248,26 @@ public class StringAssertions : ReferenceTypeAssertions<string, StringAssertions
         return new(this);
     }
 
+    /// <summary>Asserts at least one of <paramref name="values"/> is missing from the subject (ordinal).</summary>
+    public AndConstraint<StringAssertions> NotContainAll(params string[] values)
+        => NotContainAll(values, because: null);
+
+    /// <summary>
+    /// Asserts at least one of <paramref name="values"/> is missing from the subject (ordinal) — this is
+    /// the negation of <see cref="ContainAll(string[], string?, object?[])"/>, not "contains none of them";
+    /// use <see cref="NotContainAny(string[], string?, object?[])"/> for that. A null subject passes, since
+    /// it contains nothing. An empty <paramref name="values"/> fails, mirroring the positive passing
+    /// vacuously on one.
+    /// </summary>
+    public AndConstraint<StringAssertions> NotContainAll(string[] values, string? because = null, params object?[] becauseArgs)
+    {
+        ArgumentNullException.ThrowIfNull(values);
+        var missing = Array.FindAll(values, v => Subject is null || !Subject.Contains(v, StringComparison.Ordinal));
+        Assert().ForCondition(missing.Length > 0).BecauseOf(because, becauseArgs)
+            .FailWith("Did not expect {subject} to contain all of {0}{reason}, but found every one of them in {1}.", values, Subject);
+        return new(this);
+    }
+
     /// <summary>Asserts the subject contains at least one of <paramref name="values"/> (ordinal).</summary>
     public AndConstraint<StringAssertions> ContainAny(params string[] values)
         => ContainAny(values, because: null);
@@ -233,6 +279,23 @@ public class StringAssertions : ReferenceTypeAssertions<string, StringAssertions
         var any = Subject is not null && Array.Exists(values, v => Subject.Contains(v, StringComparison.Ordinal));
         Assert().ForCondition(any).BecauseOf(because, becauseArgs)
             .FailWith("Expected {subject} to contain at least one of {0}{reason}, but found {1}.", values, Subject);
+        return new(this);
+    }
+
+    /// <summary>Asserts the subject contains none of <paramref name="values"/> (ordinal); the ones it does contain are listed.</summary>
+    public AndConstraint<StringAssertions> NotContainAny(params string[] values)
+        => NotContainAny(values, because: null);
+
+    /// <summary>
+    /// Asserts the subject contains none of <paramref name="values"/> (ordinal); the ones it does contain
+    /// are listed in the failure. A null subject passes, and so does an empty <paramref name="values"/>.
+    /// </summary>
+    public AndConstraint<StringAssertions> NotContainAny(string[] values, string? because = null, params object?[] becauseArgs)
+    {
+        ArgumentNullException.ThrowIfNull(values);
+        var found = Array.FindAll(values, v => Subject is not null && Subject.Contains(v, StringComparison.Ordinal));
+        Assert().ForCondition(found.Length == 0).BecauseOf(because, becauseArgs)
+            .FailWith("Did not expect {subject} to contain any of {0}{reason}, but found {1} in {2}.", values, found, Subject);
         return new(this);
     }
 
@@ -260,6 +323,15 @@ public class StringAssertions : ReferenceTypeAssertions<string, StringAssertions
         ArgumentNullException.ThrowIfNull(wildcardPattern);
         Assert().ForCondition(WildcardPattern.IsMatch(Subject, wildcardPattern, ignoreCase: true)).BecauseOf(because, becauseArgs)
             .FailWith("Expected {subject} to match the equivalent of {0}{reason}, but found {1}.", wildcardPattern, Subject);
+        return new(this);
+    }
+
+    /// <summary>Asserts the subject does not match the wildcard pattern, ignoring casing (a null subject matches nothing, so it passes).</summary>
+    public AndConstraint<StringAssertions> NotMatchEquivalentOf(string wildcardPattern, string? because = null, params object?[] becauseArgs)
+    {
+        ArgumentNullException.ThrowIfNull(wildcardPattern);
+        Assert().ForCondition(!WildcardPattern.IsMatch(Subject, wildcardPattern, ignoreCase: true)).BecauseOf(because, becauseArgs)
+            .FailWith("Did not expect {subject} to match the equivalent of {0}{reason}, but found {1}.", wildcardPattern, Subject);
         return new(this);
     }
 
@@ -293,6 +365,18 @@ public class StringAssertions : ReferenceTypeAssertions<string, StringAssertions
         return new(this);
     }
 
+    /// <summary>
+    /// Asserts the subject is not upper-cased, i.e. it holds at least one lower-case letter. A string with
+    /// no letters at all — "42" — is upper-cased by <see cref="BeUpperCased"/>'s reckoning and therefore
+    /// fails here. A null subject passes, as with the other negatives on this class.
+    /// </summary>
+    public AndConstraint<StringAssertions> NotBeUpperCased(string? because = null, params object?[] becauseArgs)
+    {
+        Assert().ForCondition(Subject is null || ContainsLetterWhere(Subject, char.IsLower)).BecauseOf(because, becauseArgs)
+            .FailWith("Did not expect {subject} to be upper-cased{reason}, but found {0}.", Subject);
+        return new(this);
+    }
+
     /// <summary>Asserts every letter in the subject is lower-cased (non-letters are ignored).</summary>
     public AndConstraint<StringAssertions> BeLowerCased(string? because = null, params object?[] becauseArgs)
     {
@@ -300,6 +384,18 @@ public class StringAssertions : ReferenceTypeAssertions<string, StringAssertions
             .FailWith("Expected {subject} to be lower-cased{reason}, but found <null>.")
             .ForCondition(Subject is null || !ContainsLetterWhere(Subject, char.IsUpper)).BecauseOf(because, becauseArgs)
             .FailWith("Expected {subject} to be lower-cased{reason}, but found {0}.", Subject);
+        return new(this);
+    }
+
+    /// <summary>
+    /// Asserts the subject is not lower-cased, i.e. it holds at least one upper-case letter. As with
+    /// <see cref="NotBeUpperCased"/>, a string with no letters at all counts as lower-cased and fails here.
+    /// A null subject passes.
+    /// </summary>
+    public AndConstraint<StringAssertions> NotBeLowerCased(string? because = null, params object?[] becauseArgs)
+    {
+        Assert().ForCondition(Subject is null || ContainsLetterWhere(Subject, char.IsUpper)).BecauseOf(because, becauseArgs)
+            .FailWith("Did not expect {subject} to be lower-cased{reason}, but found {0}.", Subject);
         return new(this);
     }
 

--- a/Assertions/MintPlayer.Assertions/Primitives/TimeOnlyAssertions.cs
+++ b/Assertions/MintPlayer.Assertions/Primitives/TimeOnlyAssertions.cs
@@ -52,6 +52,19 @@ public class TimeOnlyAssertions
         return new(this);
     }
 
+    /// <summary>
+    /// Asserts the subject is not within <paramref name="precision"/> of <paramref name="distantTime"/>,
+    /// measuring the same shortest distance around the clock as <see cref="BeCloseTo"/> (so 00:01 is not
+    /// far from 23:59). A null subject passes.
+    /// </summary>
+    public AndConstraint<TimeOnlyAssertions> NotBeCloseTo(TimeOnly distantTime, TimeSpan precision, string? because = null, params object?[] becauseArgs)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(precision, TimeSpan.Zero);
+        Assert().ForCondition(!Subject.HasValue || Distance(Subject.Value, distantTime) > precision).BecauseOf(because, becauseArgs)
+            .FailWith("Did not expect {subject} to be within {0} of {1}{reason}, but found {2}.", precision, distantTime, Subject);
+        return new(this);
+    }
+
     /// <summary>Asserts the subject is strictly before <paramref name="expected"/>.</summary>
     public AndConstraint<TimeOnlyAssertions> BeBefore(TimeOnly expected, string? because = null, params object?[] becauseArgs)
     {

--- a/Assertions/MintPlayer.Assertions/Primitives/TimeSpanAssertions.cs
+++ b/Assertions/MintPlayer.Assertions/Primitives/TimeSpanAssertions.cs
@@ -48,11 +48,27 @@ public class TimeSpanAssertions
         return new(this);
     }
 
+    /// <summary>Asserts the subject is not greater than <see cref="TimeSpan.Zero"/> — zero and negative spans pass, and so does null.</summary>
+    public AndConstraint<TimeSpanAssertions> NotBePositive(string? because = null, params object?[] becauseArgs)
+    {
+        Assert().ForCondition(Subject is not { } value || value <= TimeSpan.Zero).BecauseOf(because, becauseArgs)
+            .FailWith("Did not expect {subject} to be positive{reason}, but found {0}.", Subject);
+        return new(this);
+    }
+
     /// <summary>Asserts the subject is less than <see cref="TimeSpan.Zero"/>.</summary>
     public AndConstraint<TimeSpanAssertions> BeNegative(string? because = null, params object?[] becauseArgs)
     {
         Assert().ForCondition(Subject < TimeSpan.Zero).BecauseOf(because, becauseArgs)
             .FailWith("Expected {subject} to be negative{reason}, but found {0}.", Subject);
+        return new(this);
+    }
+
+    /// <summary>Asserts the subject is not less than <see cref="TimeSpan.Zero"/> — zero and positive spans pass, and so does null.</summary>
+    public AndConstraint<TimeSpanAssertions> NotBeNegative(string? because = null, params object?[] becauseArgs)
+    {
+        Assert().ForCondition(Subject is not { } value || value >= TimeSpan.Zero).BecauseOf(because, becauseArgs)
+            .FailWith("Did not expect {subject} to be negative{reason}, but found {0}.", Subject);
         return new(this);
     }
 
@@ -62,6 +78,15 @@ public class TimeSpanAssertions
         ArgumentOutOfRangeException.ThrowIfLessThan(precision, TimeSpan.Zero);
         Assert().ForCondition(Subject.HasValue && Distance(Subject.Value, nearbyTime) <= precision).BecauseOf(because, becauseArgs)
             .FailWith("Expected {subject} to be within {0} of {1}{reason}, but found {2}.", precision, nearbyTime, Subject);
+        return new(this);
+    }
+
+    /// <summary>Asserts the subject is not within <paramref name="precision"/> of <paramref name="distantTime"/> (a null subject passes).</summary>
+    public AndConstraint<TimeSpanAssertions> NotBeCloseTo(TimeSpan distantTime, TimeSpan precision, string? because = null, params object?[] becauseArgs)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(precision, TimeSpan.Zero);
+        Assert().ForCondition(!Subject.HasValue || Distance(Subject.Value, distantTime) > precision).BecauseOf(because, becauseArgs)
+            .FailWith("Did not expect {subject} to be within {0} of {1}{reason}, but found {2}.", precision, distantTime, Subject);
         return new(this);
     }
 

--- a/Assertions/MintPlayer.Assertions/Primitives/TypeAssertions.cs
+++ b/Assertions/MintPlayer.Assertions/Primitives/TypeAssertions.cs
@@ -54,6 +54,19 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
         return new(this);
     }
 
+    /// <summary>
+    /// Asserts the type does not derive from <typeparamref name="TBase"/>. Mirrors
+    /// <see cref="BeDerivedFrom{TBase}"/>, so the type itself is not "derived from" itself and passes;
+    /// a null subject passes as well.
+    /// </summary>
+    public AndConstraint<TypeAssertions> NotBeDerivedFrom<TBase>(string? because = null, params object?[] becauseArgs)
+        where TBase : class
+    {
+        Assert().ForCondition(Subject is null || !Subject.IsSubclassOf(typeof(TBase))).BecauseOf(because, becauseArgs)
+            .FailWith("Did not expect {subject} to be derived from {0}{reason}.", typeof(TBase));
+        return new(this);
+    }
+
     /// <summary>Asserts the type implements the interface <typeparamref name="TInterface"/>.</summary>
     public AndConstraint<TypeAssertions> Implement<TInterface>(string? because = null, params object?[] becauseArgs)
     {
@@ -62,6 +75,22 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
 
         Assert().ForCondition(Subject is not null && Subject != typeof(TInterface) && typeof(TInterface).IsAssignableFrom(Subject)).BecauseOf(because, becauseArgs)
             .FailWith("Expected {subject} to implement {0}{reason}, but found {1}.", typeof(TInterface), Subject);
+        return new(this);
+    }
+
+    /// <summary>
+    /// Asserts the type does not implement the interface <typeparamref name="TInterface"/>. Mirrors
+    /// <see cref="Implement{TInterface}"/>: the interface itself does not "implement" itself and passes,
+    /// as does a null subject. A non-interface <typeparamref name="TInterface"/> is a caller mistake and
+    /// still throws rather than quietly passing.
+    /// </summary>
+    public AndConstraint<TypeAssertions> NotImplement<TInterface>(string? because = null, params object?[] becauseArgs)
+    {
+        if (!typeof(TInterface).IsInterface)
+            throw new ArgumentException($"{typeof(TInterface)} must be an interface.", nameof(TInterface));
+
+        Assert().ForCondition(Subject is null || Subject == typeof(TInterface) || !typeof(TInterface).IsAssignableFrom(Subject)).BecauseOf(because, becauseArgs)
+            .FailWith("Did not expect {subject} to implement {0}{reason}.", typeof(TInterface));
         return new(this);
     }
 
@@ -112,11 +141,34 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
         return new(this);
     }
 
+    /// <summary>
+    /// Asserts the type is not abstract in the sense <see cref="BeAbstract"/> means it: a static class is
+    /// abstract-and-sealed at the IL level but is reported as static, not abstract, so it passes here.
+    /// A null subject passes.
+    /// </summary>
+    public AndConstraint<TypeAssertions> NotBeAbstract(string? because = null, params object?[] becauseArgs)
+    {
+        Assert().ForCondition(Subject is not { IsAbstract: true, IsSealed: false }).BecauseOf(because, becauseArgs)
+            .FailWith("Did not expect {subject} to be abstract{reason}.");
+        return new(this);
+    }
+
     /// <summary>Asserts the type is sealed (and not static, i.e. not also abstract).</summary>
     public AndConstraint<TypeAssertions> BeSealed(string? because = null, params object?[] becauseArgs)
     {
         Assert().ForCondition(Subject is { IsSealed: true, IsAbstract: false }).BecauseOf(because, becauseArgs)
             .FailWith("Expected {subject} to be sealed{reason}, but found {0}.", Subject);
+        return new(this);
+    }
+
+    /// <summary>
+    /// Asserts the type is not sealed in the sense <see cref="BeSealed"/> means it, so a static class
+    /// passes here for the same reason it passes <see cref="NotBeAbstract"/>. A null subject passes.
+    /// </summary>
+    public AndConstraint<TypeAssertions> NotBeSealed(string? because = null, params object?[] becauseArgs)
+    {
+        Assert().ForCondition(Subject is not { IsSealed: true, IsAbstract: false }).BecauseOf(because, becauseArgs)
+            .FailWith("Did not expect {subject} to be sealed{reason}.");
         return new(this);
     }
 
@@ -128,6 +180,14 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
         return new(this);
     }
 
+    /// <summary>Asserts the type is not static, i.e. not both abstract and sealed (a null subject passes).</summary>
+    public AndConstraint<TypeAssertions> NotBeStatic(string? because = null, params object?[] becauseArgs)
+    {
+        Assert().ForCondition(Subject is not { IsAbstract: true, IsSealed: true }).BecauseOf(because, becauseArgs)
+            .FailWith("Did not expect {subject} to be static{reason}.");
+        return new(this);
+    }
+
     /// <summary>Asserts the type is an interface.</summary>
     public AndConstraint<TypeAssertions> BeAnInterface(string? because = null, params object?[] becauseArgs)
     {
@@ -136,11 +196,31 @@ public class TypeAssertions : ReferenceTypeAssertions<Type, TypeAssertions>
         return new(this);
     }
 
+    /// <summary>Asserts the type is not an interface — a struct, enum or class all pass, and so does a null subject.</summary>
+    public AndConstraint<TypeAssertions> NotBeAnInterface(string? because = null, params object?[] becauseArgs)
+    {
+        Assert().ForCondition(Subject is not { IsInterface: true }).BecauseOf(because, becauseArgs)
+            .FailWith("Did not expect {subject} to be an interface{reason}.");
+        return new(this);
+    }
+
     /// <summary>Asserts the type is a class.</summary>
     public AndConstraint<TypeAssertions> BeAClass(string? because = null, params object?[] becauseArgs)
     {
         Assert().ForCondition(Subject is { IsClass: true }).BecauseOf(because, becauseArgs)
             .FailWith("Expected {subject} to be a class{reason}, but found {0}.", Subject);
+        return new(this);
+    }
+
+    /// <summary>
+    /// Asserts the type is not a class. <see cref="Type.IsClass"/> counts delegates as classes and
+    /// interfaces as not classes, so an interface passes here while a delegate type fails.
+    /// A null subject passes.
+    /// </summary>
+    public AndConstraint<TypeAssertions> NotBeAClass(string? because = null, params object?[] becauseArgs)
+    {
+        Assert().ForCondition(Subject is not { IsClass: true }).BecauseOf(because, becauseArgs)
+            .FailWith("Did not expect {subject} to be a class{reason}.");
         return new(this);
     }
 

--- a/Assertions/MintPlayer.Assertions/README.md
+++ b/Assertions/MintPlayer.Assertions/README.md
@@ -182,6 +182,43 @@ Options (`NotBeEquivalentTo` takes the same):
 | `ComparingByValue<T>()` / `ComparingByMembers<T>()` | Force `Equals` or member-wise comparison for a type |
 | `WithMaxDepth(n)` / `AllowingInfiniteRecursion()` | Bound or unbound recursion (default depth 10) |
 | `RespectingRuntimeTypes()` | Resolve members from runtime types instead of declared ones |
+| `AllowingVacuousComparison()` | Permit a comparison that compares no members at all (see below) |
+
+`Excluding` and `Including` take a path relative to the **comparison root**. On a collection
+subject the root is the collection, so an element's member lives at `[0].Name` — reach it with
+`ExcludingNested<T>` or a wildcard path, not `Excluding(x => x.Name)`.
+
+#### Assertions that cannot fail are refused
+
+The comparison is driven by the *expectation's* members, and extra subject members are ignored —
+that is what makes comparing a DTO against an anonymous object work. The degenerate consequence is
+that an expectation contributing **no** members yields no differences, so `BeEquivalentTo` would
+pass for any two values and `NotBeEquivalentTo` would fail for any two values. Silently.
+
+That is refused with an `InvalidOperationException` naming both types and the cause:
+
+```
+No members were compared, so this assertion can never fail: the expectation type 'Object'
+exposes no public properties or fields, while the subject 'Invoice' has 2. Compare against a
+concrete type, or against an anonymous object listing the members you care about — or call
+AllowingVacuousComparison() if comparing nothing is intended.
+```
+
+It is thrown rather than reported as a failure because a failure is exactly what would make
+`NotBeEquivalentTo` *succeed* — hiding the mistake where it is easiest to make.
+
+An expectation type with **no comparable members** is refused wherever it appears, including on a
+collection element or a nested member, since it is never a way to express intent. Options that
+**removed every member** are refused only at the root, where nothing is left to assert — deeper
+down, excluding every member of a subtree is the normal way to skip it, exactly as
+`ExcludingNested<AuditInfo>(a => a.ModifiedOn)` does above. Two values that both expose no members
+are genuinely equivalent and still compare equal; so do two empty collections. Use
+`AllowingVacuousComparison()` for a generic harness where some instantiations legitimately have
+nothing to compare.
+
+Casting to `object` does **not** disable the comparison — members are resolved from the runtime
+type. It does cost the generated accessors and make the options lambda untypeable, which is what
+[MPA0004](#analyzers) points out.
 
 ```csharp
 actual.Should().BeEquivalentTo(expected, opt => opt
@@ -260,7 +297,7 @@ ratio.Should().BeInRange(0, 1);
 `NotContain` `ContainInOrder` `OnlyContain` `OnlyHaveUniqueItems` `NotContainNulls` `Equal`
 `NotEqual` `StartWith` `EndWith` `BeInAscendingOrder` `BeInDescendingOrder` `BeSubsetOf`
 `NotBeSubsetOf` `IntersectWith` `NotIntersectWith` `AllSatisfy` `SatisfyRespectively`
-`AllBeOfType<T>` `AllBeAssignableTo<T>`
+`AllBeOfType<T>` `AllBeAssignableTo<T>` `BeEquivalentTo` `NotBeEquivalentTo`
 
 ```csharp
 orders.Should().BeInAscendingOrder(o => o.PlacedOn);
@@ -280,10 +317,21 @@ are safe.
 ### Dictionaries
 
 `BeEmpty` `NotBeEmpty` `HaveCount` `ContainKey` `ContainKeys` `NotContainKey` `ContainValue`
-`ContainValues` `NotContainValue` `Contain` `NotContain`
+`ContainValues` `NotContainValue` `Contain` `NotContain` `BeEquivalentTo` `NotBeEquivalentTo`
 
 ```csharp
 versions.Should().ContainKey("Newtonsoft.Json").Which.Should().Be("13.0.3");
+```
+
+`BeEquivalentTo` compares dictionaries structurally: every expected key present with an
+equivalent value, and no unexpected keys. Values go through the full object-graph comparison, so
+the values can be anonymous objects listing only the members you care about.
+
+```csharp
+lanes.Should().BeEquivalentTo(new Dictionary<string, object>
+{
+    ["left"] = new { Width = 3 },
+});
 ```
 
 Key lookups honour the dictionary's **own** comparer, so a
@@ -439,6 +487,7 @@ Shipped in the package; no extra reference, no configuration.
 | **MPA0001** | **Error** | An async assertion whose `Task` is discarded. The test would pass no matter what the assertion found. Code fix adds `await` (and makes the method `async`). |
 | **MPA0002** | Warning | `Should()` with no assertion called on it — it does nothing. |
 | **MPA0003** | Warning | An `AssertionScope` that is never disposed, which silently swallows every failure it collected. Code fix converts it to a `using` declaration. |
+| **MPA0004** | Info | An equivalency expectation cast to `object`. The comparison is still correct, but it falls back to reflection instead of the generated accessors and cannot be configured with `Excluding`/`Including`. |
 | **MPA0100** | Info | A file still using FluentAssertions, with a code fix that migrates it. |
 | **MPAG001** | Warning | A `[GenerateAssertion]` method whose shape is unsupported, so no assertion was generated. |
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [x] 🐛 Bug Fix
- [x] 📝 Documentation Update
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 📦 Chore (Release)

## Description

**The issue's diagnosis was wrong, and its proposed fix would have broken working code.** #177 reported two things. The missing collection `NotBeEquivalentTo` overload is real. The claim that casting to `object` "silently disables the comparison" is not — `ResolveNodeType` has mapped a declared `typeof(object)` back to the runtime type since the library's first commit, so a both-cast comparison still walks the real members. Verified empirically, with a control proving the path is not merely always-failing. The suggested guard (`typeof(T) == typeof(object)` → throw) would have rejected that working code while missing the actual hole.

**The actual hole** is an expectation contributing zero comparable members. Since the comparison is expectation-driven, such a node yields no differences — so `BeEquivalentTo` passes for any two values and `NotBeEquivalentTo` fails for any two values. A green regression fence over a code path nobody is checking.

**Reachability.** Collection `NotBeEquivalentTo<T, TExpectation>`, plus dictionary `BeEquivalentTo`/`NotBeEquivalentTo`. `CompareDictionaries` already existed and worked, but no assertion reached it — which is why every dictionary test in the repo cast to `object` first. No generator change needed: `IsEquivalencyInvocation` already matches both names.

**Vacuity guard.** Detected per node in `CompareMembers`, so it also catches vacuity nested inside an otherwise-meaningful comparison. A global assertion counter cannot: `new object[]{ dto }` vs `new object[]{ new object() }` performs a real length assertion, which is the weakness of FluentAssertions' root-only guard. Split by cause — a memberless expectation *type* is refused at any depth, while options that removed every member are refused only at the root. Deeper down, excluding every member of a subtree is idiomatic "skip this subtree", as this package's own README sample `ExcludingNested((AuditInfo a) => a.ModifiedOn)` does; the first cut of the guard fired on it. That is FluentAssertions' root restriction (their #1604) applied only to the half that needs it.

Throws `InvalidOperationException` rather than failing the assertion: a failure is exactly what makes `NotBeEquivalentTo` succeed, hiding the mistake in the direction where it is easiest to make. Opt out with `AllowingVacuousComparison()` — an escape hatch neither FluentAssertions, AwesomeAssertions nor Shouldly offers.

**MPA0004 (Info).** An expectation deliberately cast to `object`. The comparison stays correct, but `EquivalencyScanner` registers nothing for `System.Object`, so it falls back to reflection — the cost and trim-safety the README advertises away — and `Excluding`/`Including` become untypeable. Requires an explicit cast on *both* sides, so the existing `Should((object)actual).BeEquivalentTo(expected)` form stays silent.

**~54 missing negative mirrors**, several inconsistent with a sibling class that already had them: `NotBeCloseTo` (TimeOnly, TimeSpan), `NotBeInRange` (Comparable), `NotBeDerivedFrom`/`NotImplement` (Type), `NotBeDefined` (Enum), `NotBeOneOf` across the numeric and date types, the `NotHave*` component family, eight string negatives, and on collections/dictionaries `NotHaveCount`, `NotStartWith`/`NotEndWith`, `NotContainInOrder`, `NotOnlyContain`, `NotContainKeys`/`NotContainValues`, `NotContain(KeyValuePair)`. Plus the one reverse gap: `ContainNulls`, the missing positive of `NotContainNulls`.

Negatives are exact negations rather than convenient approximations, with the consequences documented on each: NaN passes `NotBePositive`, a static class passes both `NotBeAbstract` and `NotBeSealed`, `"42"` fails both `NotBeUpperCased` and `NotBeLowerCased`, and the universally-quantified negatives fail on an empty collection.

**Docs** cover the guard, dictionary equivalency, MPA0004, and the root-relative `Excluding` trap — on a collection subject an element member sits at `[0].Name`, so `Excluding(x => x.Name)` silently does not apply. New samples are wired into `ReadmeSamplesTests` so they cannot rot.

**Version → 1.1.0.** Behavioural break for downstream tests that pass vacuously today; those tests assert nothing, which is the point. No committed test in this repo breaks — all 81 existing call sites cast only the subject.

873 tests pass on net8.0/net9.0/net10.0; 65 generator and analyzer tests pass. The collection and primitive mirrors were mutation-tested: every new assertion condition forced both ways, each new test broken by at least one mutation.

## Related Tickets & Documents

- Fixes #177

## Screenshots/Recordings

n.v.t. — geen UI-wijzigingen. Dit is een assertion-library; het bewijs zit in de tests (873 × 3 TFM's) en in de mutatietests.

## Checklist

- [x] ~~Ran **Synchronize**~~ N/A — no model changes
- [x] ~~Verified new functionality for the correct app roles~~ N/A — no authorization changes
- [x] ~~Ensured there are no database indexing errors~~ N/A — no database changes

## Added to documentation?

- [x] 📜 README.md
- [ ] 📜 SERVICES.md
- [ ] 📜 specific docs/ file
- [ ] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?

The version bump to 1.1.0 publishes on merge. The vacuity guard is a behavioural break for consumers whose tests pass vacuously today, so the release notes should call it out along with the `AllowingVacuousComparison()` opt-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
